### PR TITLE
19 profile fields

### DIFF
--- a/1-src/api/auth/auth-types.mts
+++ b/1-src/api/auth/auth-types.mts
@@ -2,9 +2,17 @@ import { Request, Response, NextFunction} from "express";
 import { IncomingHttpHeaders } from "http";
 import { DB_USER } from "../../services/database/database-types.mjs";
 import { GenderEnum, ProfileResponse, RoleEnum, StageEnum } from "../profile/profile-types.mjs";
+import { JwtPayload } from "jsonwebtoken";
 
 
 /*    Type Declarations     */
+export interface JWTData extends JwtPayload {
+    jwtUserId: number;
+    jwtUserRole:RoleEnum;
+    token?: string;
+}
+
+
 export interface SignupRequest extends Request {
     body: {
         email: string, 

--- a/1-src/api/auth/auth-utilities.mts
+++ b/1-src/api/auth/auth-utilities.mts
@@ -6,12 +6,12 @@ import { query, queryAll, queryTest, TestResult } from "../../services/database/
 import { DB_USER } from "../../services/database/database-types.mjs";
 import { RoleEnum } from "../profile/profile-types.mjs";
 import { formatProfile } from "../profile/profile-utilities.mjs";
-import JWT_PKG, { JwtPayload, decode } from "jsonwebtoken";
+import JWT_PKG, { JwtPayload } from "jsonwebtoken";
 import { createHash } from 'node:crypto'
 import dotenv from 'dotenv';
 dotenv.config(); 
 
-const {sign, verify} = JWT_PKG;
+const {sign, verify, decode} = JWT_PKG;
 
 /********************
    Create secret key
@@ -28,8 +28,8 @@ generateSecretKey();
  JWT Token Management
 ******************* */
 export const generateJWT = (userProfile:DB_USER):string => {
-    //generate JWT
-    return sign({userID: userProfile.user_id, userRole: userProfile.user_role}, APP_SECRET_KEY, {expiresIn: "2 days"});
+    //generate JWT as type JWTData
+    return sign({jwtUserId: userProfile.user_id, jwtUserRole: userProfile.user_role}, APP_SECRET_KEY, {expiresIn: "2 days"});
 }
 
 export const verifyJWT = (JWT:string):Boolean => {
@@ -37,7 +37,7 @@ export const verifyJWT = (JWT:string):Boolean => {
         verify(JWT, APP_SECRET_KEY);
         return true;
     } catch(err) {
-        console.log(err);
+        log.auth("Failed to verify JWT", err);
         return false;
     }
 }
@@ -48,7 +48,7 @@ export const getJWTData = (JWT:string):JWTData => {
     if('jwtUserId' in (tokenObject as JWTData)) { //Must use type predicates
         return {
             jwtUserId: (tokenObject as JWTData).jwtUserId,
-            jwtUserRole: RoleEnum[(tokenObject as JWTData).jwtRoleEnum as string],
+            jwtUserRole: RoleEnum[(tokenObject as JWTData).jwtUserRole as string],
         }
     } 
     //Default

--- a/1-src/api/profile/profile-field-config.mts
+++ b/1-src/api/profile/profile-field-config.mts
@@ -1,0 +1,97 @@
+import { GenderEnum, RoleEnum } from "./profile-types.mjs";
+
+const EMAIL_REGEX = new RegExp(/^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()\.,;\s@\"]+\.{0,1})+([^<>()\.,;:\s@\"]{2,}|[\d\.]+))$/);
+const DATE_REGEX = new RegExp(/\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2]\d|3[0-1])T(?:[0-1]\d|2[0-3]):[0-5]\d:[0-5]\dZ/); //1970-01-01T00:00:00.013Z
+    
+export enum InputType {
+    TEXT = 'TEXT',
+    NUMBER = 'NUMBER',
+    EMAIL = 'EMAIL',
+    PASSWORD = 'PASSWORD',
+    DATE = 'DATE',
+    SELECT_LIST = 'SELECT_LIST',
+    PARAGRAPH = 'PARAGRAPH'
+}
+
+export class InputField {
+    title: string;
+    field: string;
+    value: string | number;
+    type: InputType;
+    required: boolean;
+    unique: boolean;
+    validationRegex: RegExp;
+    validationMessage: string;
+    selectOptionList: string[] | number[];
+
+    constructor({title, field, value, type=InputType.TEXT, required=false, unique=false, validationRegex=new RegExp('/.*/'), validationMessage='Invalid Input', selectOptionList=[]} :
+        {title:string, field:string, value?:number | string, type?: InputType, required?:boolean, unique?:boolean, validationRegex?: RegExp, validationMessage?: string, selectOptionList?: string[]|number[]}) {
+        this.title = title;
+        this.field = field;
+        this.value = value;
+        this.type = type;
+        this.unique = unique;
+        this.required = unique || required;
+        this.validationRegex = validationRegex;
+        this.validationMessage = validationMessage;
+        this.selectOptionList = selectOptionList;
+    };
+
+    setValue(value: string | number): void {this.value = value; }
+
+    toJSON() {
+        return {
+            title: this.title,
+            field: this.field,
+            value: this.value || '',
+            type: this.type,
+            required: this.required,
+            validationRegex: this.validationRegex.source,
+            validationMessage: this.validationMessage,
+            selectOptionList: this.selectOptionList
+        };
+    }
+}
+
+const getDateYearsAgo = (years: number = 13):Date => {
+    let date = new Date();
+    date.setFullYear(date.getFullYear() - years);
+    return date;
+}
+
+//Note: extending list forces the order, may need a sortID or duplicating for now
+export const EDIT_PROFILE_FIELDS = [
+    new InputField({title: 'First Name', field: 'firstName', required: true, validationRegex: new RegExp(/.{1,30}/), validationMessage: 'Required, max 30 characters.' }),
+    new InputField({title: 'Last Name', field: 'lastName', required: true, validationRegex: new RegExp(/.{1,30}/), validationMessage: 'Required, max 30 characters.' }),
+    new InputField({title: 'Public Name', field: 'displayName', unique: true, validationRegex: new RegExp(/.{1,15}/), validationMessage: 'Must be unique, max 15 characters.' }),
+    new InputField({title: 'Password', field: 'password', type: InputType.PASSWORD, required: true, validationRegex: new RegExp(/.{5,20}/), validationMessage: 'Required, 5-20 characters.' }),
+    new InputField({title: 'Verify Password', field: 'passwordVerify', type: InputType.PASSWORD, required: true, validationRegex: new RegExp(/.{5,20}/), validationMessage: 'Required, must match password field.' }),
+    new InputField({title: 'Postal Code', field: 'postalCode', required: true, validationRegex: new RegExp(/.{5,15}/), validationMessage: 'Required, 5-15 characters.' }),
+];
+
+export const SIGNUP_PROFILE_FIELDS_STUDENT = [
+    new InputField({title: 'First Name', field: 'firstName', required: true, validationRegex: new RegExp(/.{1,30}/), validationMessage: 'Required, max 30 characters.' }),
+    new InputField({title: 'Last Name', field: 'lastName', required: true, validationRegex: new RegExp(/.{1,30}/), validationMessage: 'Required, max 30 characters.' }),
+    new InputField({title: 'Public Name', field: 'displayName', unique: true, validationRegex: new RegExp(/.{1,15}/), validationMessage: 'Must be unique, max 15 characters.' }),
+    new InputField({title: 'Email Address', field: 'email', type: InputType.EMAIL, unique: true,  validationRegex: EMAIL_REGEX, validationMessage: 'Required, invalid email format.' }),
+    new InputField({title: 'Password', field: 'password', type: InputType.PASSWORD, required: true, validationRegex: new RegExp(/.{5,20}/), validationMessage: 'Required, 5-20 characters.' }),
+    new InputField({title: 'Verify Password', field: 'passwordVerify', type: InputType.PASSWORD, required: true, validationRegex: new RegExp(/.{5,20}/), validationMessage: 'Required, must match password field.' }),
+    new InputField({title: 'Postal Code', field: 'postalCode', required: true, validationRegex: new RegExp(/.{5,15}/), validationMessage: 'Required, 5-15 characters.' }),
+    new InputField({title: 'Gender', field: 'gender', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.keys(GenderEnum)}),
+    new InputField({title: 'Date of Birth', field: 'dateOfBirth', type: InputType.DATE, value: getDateYearsAgo().toJSON(), required: true, validationRegex: DATE_REGEX, validationMessage: 'Required, invalid UTC date format.' }),
+];
+
+//SIGNUP all other roles
+export const SIGNUP_PROFILE_FIELDS = [    
+    new InputField({title: 'Account Type', field: 'userRole', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.keys(RoleEnum)}),
+    new InputField({title: 'New Account Token', field: 'token', type: InputType.TEXT, required: true}),
+    ...SIGNUP_PROFILE_FIELDS_STUDENT,
+];
+
+//SIGNUP and EDIT
+export const PROFILE_FIELDS_ADMIN = [    
+    new InputField({title: 'Active Account', field: 'isActive', required: true, type: InputType.SELECT_LIST, selectOptionList: ['TRUE', 'FALSE']}),
+    ...SIGNUP_PROFILE_FIELDS,
+    new InputField({title: 'Walk Level', field: 'walkLevel', required: true, type: InputType.SELECT_LIST, selectOptionList: [1,2,3,4,5,6,7,8,9,10]}),
+    new InputField({title: 'Profile Notes', field: 'notes', type: InputType.PARAGRAPH, validationRegex: new RegExp(/.{0,3000}/), validationMessage: 'Max 3000 characters.'}),
+];

--- a/1-src/api/profile/profile-types.mts
+++ b/1-src/api/profile/profile-types.mts
@@ -4,6 +4,7 @@ import { IncomingHttpHeaders } from 'http';
 import { IdentityClientRequest, IdentityRequest } from '../auth/auth-types.mjs';
 import { Message } from '../chat/chat-types.mjs';
 import { PrayerRequest } from '../prayer-request/prayer-request-types.mjs';
+import { EDIT_PROFILE_FIELDS, PROFILE_FIELDS_ADMIN, SIGNUP_PROFILE_FIELDS, SIGNUP_PROFILE_FIELDS_STUDENT } from './profile-field-config.mjs';
 
 export enum StageEnum {
     LEARNING = 'LEARNING',
@@ -26,33 +27,6 @@ export enum RoleEnum {
 export const getRoleList = ():string[] => 
     ([...Object.values(RoleEnum)].filter(role => role != RoleEnum.SIGNUP));
 
-//Profile Privilege Lists
-//using UI JSON Names
-export const ALL_PROFILE_FIELDS_EDIT_LIST = [
-    'userRole', 'email', 'displayName', 'password', 'phone', 'zipcode', 'dob', 'gender', 'dailyNotificationHour',
-    'stage', 'notes'
-];
-
-//Also required Fields for Profile Edit
-export const SIGNUP_PROFILE_FIELDS_CREATE_LIST = [
-    'userRole', 'email', 'displayName', 'password', 'phone', 'zipcode', 'dob', 'gender', 'dailyNotificationHour'];
-
-export const STUDENT_PROFILE_FIELDS_EDIT_LIST:string[] = ['zipcode', 'dailyNotificationHour', 'circleList', 'profileList'];
-
-export const LEADER_PROFILE_FIELDS_EDIT_LIST:string[] = [...STUDENT_PROFILE_FIELDS_EDIT_LIST, 'phone', 'stage', 'notes'];
-
-export const getUserRoleProfileAccessList = (userRole:RoleEnum):string[] => {
-    switch (userRole) {
-        case RoleEnum.SIGNUP:
-            return SIGNUP_PROFILE_FIELDS_CREATE_LIST;
-        case RoleEnum.ADMIN:
-            return ALL_PROFILE_FIELDS_EDIT_LIST;
-        case RoleEnum.LEADER:
-            return LEADER_PROFILE_FIELDS_EDIT_LIST;
-        default:
-            return STUDENT_PROFILE_FIELDS_EDIT_LIST;        
-    }
-}
 
 //Used for Inserting new profile into to Database; provided fields then overwrite
 export const getDatabaseDefaultProfileFields = ():Map<string, any> => new Map<string, any>([
@@ -66,11 +40,20 @@ export const getDatabaseDefaultProfileFields = ():Map<string, any> => new Map<st
     ['daily_notification_hour', 9],    
 ]);
 
-export const editProfileAllowed = (field:string, userRole:RoleEnum):boolean => {
-    if(!field.length || !ALL_PROFILE_FIELDS_EDIT_LIST.includes(field))
-        return false;
+export const editProfileFieldAllowed = (field:string, userRole:RoleEnum):boolean => {
+    if(userRole === RoleEnum.ADMIN)
+        return PROFILE_FIELDS_ADMIN.some(inputField => inputField.field === field);
     else
-        return getUserRoleProfileAccessList(userRole).includes(field);
+        return EDIT_PROFILE_FIELDS.some(inputField => inputField.field === field);
+}
+
+export const signupProfileFieldAllowed = (field:string, userRole:RoleEnum):boolean => {
+    if(userRole === RoleEnum.ADMIN)
+        return PROFILE_FIELDS_ADMIN.some(inputField => inputField.field === field);
+    else if(userRole === RoleEnum.STUDENT)
+        return SIGNUP_PROFILE_FIELDS_STUDENT.some(inputField => inputField.field === field);
+    else
+        return SIGNUP_PROFILE_FIELDS.some(inputField => inputField.field === field);
 }
 
 //sync with Portal app-types.tsx

--- a/1-src/api/profile/profile-utilities.mts
+++ b/1-src/api/profile/profile-utilities.mts
@@ -1,4 +1,4 @@
-import { editProfileAllowed, GenderEnum, getDatabaseDefaultProfileFields, ProfileEditRequest, ProfilePartnerResponse, ProfilePublicResponse, ProfileResponse, RoleEnum, StageEnum } from "./profile-types.mjs";
+import { editProfileFieldAllowed, GenderEnum, getDatabaseDefaultProfileFields, ProfileEditRequest, ProfilePartnerResponse, ProfilePublicResponse, ProfileResponse, RoleEnum, signupProfileFieldAllowed, StageEnum } from "./profile-types.mjs";
 import database, {formatTestResult, query, queryAll, queryTest, TestResult} from "../../services/database/database.mjs";
 import { Exception } from "../api-types.mjs";
 import * as log from '../../services/log.mjs';
@@ -136,7 +136,9 @@ export const editProfile = async(editId: number, httpRequest:ProfileEditRequest 
     const getProfileChanges = (editId:number, field:[string, unknown], columnList:string[], valueList:any[], accessorUserRole:RoleEnum, editType:EDIT_TYPES = EDIT_TYPES.EDIT):boolean => {
                
         //Special Parsing Edits 
-        if( editProfileAllowed(field[0], accessorUserRole) && (
+        if( ((editType === EDIT_TYPES.CREATE && signupProfileFieldAllowed(field[0], accessorUserRole))
+            || (editType === EDIT_TYPES.EDIT && editProfileFieldAllowed(field[0], accessorUserRole))
+        ) && (
             addField('email', `email`, field[1], field[0], columnList, valueList, editType)
             || addField('displayName', `display_name`, field[1], field[0], columnList, valueList, editType)
             || addField('password', `password_hash`, getPasswordHash(field[1] as string), field[0], columnList, valueList, editType)

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -18,7 +18,7 @@ import logRoutes from './api/log/log.mjs';
 import apiRoutes from './api/api.mjs';
 
 import {GET_allUserCredentials, GET_jwtVerify, POST_login, POST_logout, POST_signup, POST_authorization_reset } from './api/auth/auth.mjs';
-import { GET_partnerProfile, GET_profileAccessUserList, GET_ProfileRoleEditList, GET_publicProfile, GET_RoleList, GET_userProfile, PATCH_userProfile, POST_EmailExists, POST_UsernameExists } from './api/profile/profile.mjs';
+import { GET_EditProfileFields, GET_partnerProfile, GET_profileAccessUserList, GET_publicProfile, GET_RoleList, GET_SignupProfileFields, GET_userProfile, PATCH_userProfile, POST_EmailExists, POST_UsernameExists } from './api/profile/profile.mjs';
 import { DELETE_prayerRequest, GET_prayerRequestCircle, GET_profilePrayerRequestSpecific, GET_prayerRequestUser, PATCH_prayerRequestAnswered, POST_prayerRequest } from './api/prayer-request/prayer-request.mjs';
 
 import { IdentityCircleRequest, IdentityClientRequest, IdentityRequest, JWTRequest } from './api/auth/auth-types.mjs';
@@ -132,7 +132,7 @@ apiServer.get('/resources/role-list', GET_RoleList);
 // apiServer.post('/resources/account-exists', POST_EmailExists);
 // apiServer.post('/resources/name-exists', POST_UsernameExists);
 
-apiServer.get('/resources/profile-edit-list', GET_ProfileRoleEditList);
+apiServer.get('/resources/signup-fields/:role', GET_SignupProfileFields);
 
 apiServer.post('/login', POST_login);
 
@@ -195,6 +195,8 @@ apiServer.get('/api/user/circle/:circle/prayer-request/:prayer', GET_profilePray
 // #4 - Verify User Profile Access
 //******************************
 apiServer.use('/api/user/profile/:client', async (request:IdentityClientRequest, response:Response, next:NextFunction) => await authenticateProfileMiddleware(request, response, next));
+
+apiServer.get('/api/user/profile/:client/edit-fields', GET_EditProfileFields);
 
 apiServer.get('/api/user/profile/:client', GET_userProfile);
 apiServer.patch('/api/user/profile/:client', PATCH_userProfile);


### PR DESCRIPTION
1) I was getting typescript errors, so I created a **JWTData** type.
Make sure you have VS code extension: **"JavaScript and TypeScript Nightly"** and **"TypeScript Importer"** installed

2) **profile-field-config.mts** will be our one source or truth for profile input fields signup and edit permissions and field requirements.

Signup Route: /resources/signup-fields/:role  (':role' can be: admin, student, leader)
Edit Profile Route: /api/user/profile/:client/edit-fields (':client' is user id)

3) **NOTE: Portal needs to be updated (redux, jwt, profile-edit-list); before this and your JWT logic on the server goes to aws production.  I'll be offline camping through Tuesday; I can click merge to master from my phone; otherwise I'll message you sample responses.   Feel free to pull the server code and run locally too.
