### PR TITLE
#47 - Prayer Request Routes

### DIFF
--- a/1-src/api/circle/circle-types.mts
+++ b/1-src/api/circle/circle-types.mts
@@ -2,6 +2,7 @@ import * as log from '../../services/log.mjs';
 import { CircleStatus } from '../../services/models/Fields-Sync/circle-field-config.mjs';
 import CIRCLE_ANNOUNCEMENT from '../../services/models/circleAnnouncementModel.mjs';
 import { JwtCircleRequest } from '../auth/auth-types.mjs';
+import { PrayerRequestListItem } from '../prayer-request/prayer-request-types.mjs';
 import { ProfileListItem } from '../profile/profile-types.mjs';
 
 /* Sync between Server and Portal "circle-types" */
@@ -42,6 +43,7 @@ export interface CircleResponse {
     memberList: ProfileListItem[],
     eventList: CircleEventListItem[],
     announcementList: CIRCLE_ANNOUNCEMENT[],
+    prayerRequestList: PrayerRequestListItem[]
 };
 
 /* Sync between Server and Portal "circle-types" */

--- a/1-src/api/circle/circle.mts
+++ b/1-src/api/circle/circle.mts
@@ -8,7 +8,8 @@ import { RoleEnum } from '../../services/models/Fields-Sync/profile-field-config
 import { CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED, CIRCLE_TABLE_COLUMNS, CIRCLE_TABLE_COLUMNS_REQUIRED, DATABASE_CIRCLE_STATUS_ENUM, DATABASE_USER_ROLE_ENUM } from '../../services/database/database-types.mjs';
 import createModelFromJSON from '../../services/models/createModelFromJson.mjs';
 import { DB_IS_USER_ROLE } from '../../services/database/queries/user-queries.mjs';
-import { CIRCLE_ANNOUNCEMENT_FIELDS, CIRCLE_FIELDS, CIRCLE_FIELDS_ADMIN, CircleStatus, InputField } from '../../services/models/Fields-Sync/circle-field-config.mjs';
+import InputField from '../../services/models/Fields-Sync/inputField.mjs';
+import { CIRCLE_ANNOUNCEMENT_FIELDS, CIRCLE_FIELDS, CIRCLE_FIELDS_ADMIN, CircleStatus } from '../../services/models/Fields-Sync/circle-field-config.mjs';
 import { CircleAnnouncementCreateRequest } from './circle-types.mjs';
 import CIRCLE_ANNOUNCEMENT from '../../services/models/circleAnnouncementModel.mjs';
 import getCircleEventSampleList from './circle-event-samples.mjs';

--- a/1-src/api/circle/circle.mts
+++ b/1-src/api/circle/circle.mts
@@ -12,6 +12,7 @@ import { CIRCLE_ANNOUNCEMENT_FIELDS, CIRCLE_FIELDS, CIRCLE_FIELDS_ADMIN, CircleS
 import { CircleAnnouncementCreateRequest } from './circle-types.mjs';
 import CIRCLE_ANNOUNCEMENT from '../../services/models/circleAnnouncementModel.mjs';
 import getCircleEventSampleList from './circle-event-samples.mjs';
+import { DB_DELETE_RECIPIENT_PRAYER_REQUEST, DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST } from '../../services/database/queries/prayer-request-queries.mjs';
 
 /******************
  *  CIRCLE ROUTES
@@ -31,7 +32,7 @@ export const GET_circle =  async(request: JwtCircleRequest, response: Response, 
     const circle:CIRCLE = await DB_SELECT_CIRCLE_DETAIL({circleID: request.circleID, userID: request.jwtUserID});
     circle.announcementList = await DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT(request.circleID);
     circle.eventList = getCircleEventSampleList(request.circleID); //TODO Define Circle Event once Implemented
-    // circle.prayerRequestList = await DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST( circle.circleID);
+    circle.prayerRequestList = await DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST( circle.circleID);
     circle.memberList = await DB_SELECT_CIRCLE_USER_LIST(circle.circleID, DATABASE_CIRCLE_STATUS_ENUM.MEMBER);
 
     if(request.jwtUserID === circle.leaderID || request.jwtUserRole === RoleEnum.ADMIN) {
@@ -120,6 +121,9 @@ export const DELETE_circle =  async(request: JwtCircleRequest, response: Respons
     if(await DB_DELETE_CIRCLE_ANNOUNCEMENT({announcementID: undefined, circleID: request.circleID}) === false)
         next(new Exception(500, `Failed to delete all announcements for circle ${request.circleID}`, 'Deleting Announcements Failed'));
 
+    else if(await DB_DELETE_RECIPIENT_PRAYER_REQUEST({circleID: request.circleID}) === false)
+        next(new Exception(500, `Failed to delete all prayer request recipient records for circle ${request.circleID}`, 'Deleting Circle Prayer Requests Failed'));
+    
     else if(await DB_DELETE_CIRCLE_USER_STATUS({userID: undefined, circleID: request.circleID}) === false)
         next(new Exception(500, `Failed to delete all user members for circle ${request.circleID}`, 'Removing Members Failed'));
 

--- a/1-src/api/prayer-request/prayer-request-types.mts
+++ b/1-src/api/prayer-request/prayer-request-types.mts
@@ -1,0 +1,51 @@
+import express, {Router, Request, Response, NextFunction} from 'express';
+import { JwtPrayerRequest, JwtRequest } from '../auth/auth-types.mjs';
+import { ProfileListItem } from '../profile/profile-types.mjs';
+import { PrayerRequestTagEnum } from '../../services/models/Fields-Sync/prayer-request-field-config.mjs';
+
+export interface PrayerRequestListItem {
+    prayerRequestID: number,
+    requestorProfile: ProfileListItem, 
+    topic: string,
+    prayerCount: number,
+    tagList: PrayerRequestTagEnum[], 
+}
+
+export interface PrayerRequestCommentListItem {
+    commentID: number,
+    prayerRequestID?: number,
+    commenterProfile: ProfileListItem, 
+    message: string,
+    likeCount: number
+}
+
+export interface PrayerRequestPostRequest extends JwtRequest {
+    body: {
+        requestorID?: number, 
+        topic: string,
+        description: string,
+        expirationDate: Date
+        prayerCount?: number,
+        isOnGoing?: boolean,
+        isResolved?: boolean,
+        tagList?: string[],
+        userRecipientIDList: number[],
+        circleRecipientIDList: number[]
+    }
+}
+
+export interface PrayerRequestPatchRequest extends JwtPrayerRequest {
+    body: PrayerRequestPostRequest['body'] & {
+        addUserRecipientIDList: number[],
+        removeUserRecipientIDList: number[],
+        addCircleRecipientIDList: number[],
+        removeCircleRecipientIDList: number[]
+    }
+}
+
+export interface PrayerRequestCommentRequest extends JwtPrayerRequest {
+    body: {
+        comment: string
+    }
+}
+

--- a/1-src/api/prayer-request/prayer-request.mts
+++ b/1-src/api/prayer-request/prayer-request.mts
@@ -8,7 +8,8 @@ import { RoleEnum } from '../../services/models/Fields-Sync/profile-field-config
 import PRAYER_REQUEST from '../../services/models/prayerRequestModel.mjs';
 import createModelFromJSON from '../../services/models/createModelFromJson.mjs';
 import { PrayerRequestCommentRequest, PrayerRequestPatchRequest, PrayerRequestPostRequest } from './prayer-request-types.mjs';
-import { CREATE_REQUEST_FIELDS, EDIT_PRAYER_REQUEST_FIELDS, InputField, PRAYER_REQUEST_COMMENT_FIELDS, PRAYER_REQUEST_FIELDS_ADMIN } from '../../services/models/Fields-Sync/prayer-request-field-config.mjs';
+import InputField from '../../services/models/Fields-Sync/inputField.mjs';
+import { CREATE_REQUEST_FIELDS, EDIT_PRAYER_REQUEST_FIELDS, PRAYER_REQUEST_COMMENT_FIELDS, PRAYER_REQUEST_FIELDS_ADMIN } from '../../services/models/Fields-Sync/prayer-request-field-config.mjs';
 
 
 /*************************************

--- a/1-src/api/profile/profile.mts
+++ b/1-src/api/profile/profile.mts
@@ -11,6 +11,7 @@ import USER from '../../services/models/userModel.mjs';
 import { DB_DELETE_CIRCLE_USER_STATUS, DB_SELECT_MEMBERS_OF_ALL_CIRCLES, DB_SELECT_USER_CIRCLES } from '../../services/database/queries/circle-queries.mjs';
 import createModelFromJSON from '../../services/models/createModelFromJson.mjs';
 import { DATABASE_USER_ROLE_ENUM } from '../../services/database/database-types.mjs';
+import { DB_DELETE_ALL_USER_PRAYER_REQUEST, DB_DELETE_PRAYER_REQUEST } from '../../services/database/queries/prayer-request-queries.mjs';
 
 //UI Helper Utility
 export const GET_RoleList = (request: Request, response: Response, next: NextFunction) => {
@@ -138,6 +139,9 @@ export const DELETE_userProfile = async (request: JwtClientRequest, response: Re
 
     // else if(await DB_DELETE_PARTNERSHIP({userID: request.clientID, partnerUserID: undefined}) === false)
     //     next(new Exception(500, `Failed to delete all partnerships of user ${request.clientID}`, 'Partnerships Exists'));
+
+    else if(await DB_DELETE_ALL_USER_PRAYER_REQUEST(request.clientID) === false)
+        next(new Exception(500, `Failed to delete all prayer requests of user ${request.clientID}`, 'Prayer Requests Exists'));
 
     else if(await DB_DELETE_USER_ROLE({userID: request.clientID, userRoleList: undefined}) === false)
         next(new Exception(500, `Failed to delete all user roles of user ${request.clientID}`, 'User Roles Exists'));

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -21,8 +21,9 @@ import apiRoutes from './api/api.mjs';
 import {GET_allUserCredentials, GET_jwtVerify, POST_login, POST_logout, POST_signup, POST_authorization_reset } from './api/auth/auth.mjs';
 import { GET_EditProfileFields, GET_partnerProfile, GET_profileAccessUserList, GET_publicProfile, GET_RoleList, GET_SignupProfileFields, GET_userProfile, PATCH_userProfile, GET_AvailableAccount, DELETE_userProfile } from './api/profile/profile.mjs';
 import { GET_publicCircle, GET_circle, POST_newCircle, DELETE_circle, DELETE_circleLeaderMember, DELETE_circleMember, PATCH_circle, POST_circleLeaderAccept, POST_circleMemberAccept, POST_circleMemberJoinAdmin, POST_circleMemberRequest, POST_circleLeaderMemberInvite, DELETE_circleAnnouncement, POST_circleAnnouncement, GET_CircleList } from './api/circle/circle.mjs';
+import { DELETE_prayerRequest, DELETE_prayerRequestComment, GET_PrayerRequest, GET_PrayerRequestRequestorDetails, GET_PrayerRequestCircleList, GET_PrayerRequestRequestorList, GET_PrayerRequestRequestorResolvedList, GET_PrayerRequestUserList, PATCH_prayerRequest, POST_prayerRequest, POST_prayerRequestComment, POST_prayerRequestCommentIncrementLikeCount, POST_prayerRequestIncrementPrayerCount, POST_prayerRequestResolved } from './api/prayer-request/prayer-request.mjs';
 
-import { authenticatePartnerMiddleware, authenticateCircleMembershipMiddleware, authenticateClientAccessMiddleware, authenticateCircleLeaderMiddleware, authenticateAdminMiddleware, jwtAuthenticationMiddleware, authenticateLeaderMiddleware, extractCircleMiddleware, extractClientMiddleware } from './api/auth/authorization.mjs';
+import { authenticatePartnerMiddleware, authenticateCircleMembershipMiddleware, authenticateClientAccessMiddleware, authenticateCircleLeaderMiddleware, authenticateAdminMiddleware, jwtAuthenticationMiddleware, authenticateLeaderMiddleware, authenticatePrayerRequestRecipientMiddleware, authenticatePrayerRequestRequestorMiddleware, extractCircleMiddleware, extractClientMiddleware } from './api/auth/authorization.mjs';
 import { GET_userContacts } from './api/chat/chat.mjs';
  
 //Import Services
@@ -146,6 +147,31 @@ apiServer.get('/api/user/profile/edit-fields', GET_EditProfileFields);
 
 apiServer.get('/api/circle-list', GET_CircleList); //optional 'search' parameter
 
+apiServer.get('/api/prayer-request/user-list', GET_PrayerRequestUserList);
+apiServer.post('/api/prayer-request', POST_prayerRequest);
+
+
+/*****************************************************************************/
+/* Authenticate Recipient to Prayer Request | cache: request.prayerRequestID */
+/*****************************************************************************/
+apiServer.use('/api/prayer-request/:prayer', (request:JwtPrayerRequest, response:Response, next:NextFunction) => authenticatePrayerRequestRecipientMiddleware(request, response, next));
+
+apiServer.get('/api/prayer-request/:prayer', GET_PrayerRequest);
+apiServer.post('/api/prayer-request/:prayer/like', POST_prayerRequestIncrementPrayerCount);
+apiServer.post('/api/prayer-request/:prayer/comment/:comment/like', POST_prayerRequestCommentIncrementLikeCount);
+apiServer.post('/api/prayer-request/:prayer/comment', POST_prayerRequestComment);
+apiServer.delete('/api/prayer-request/:prayer/comment/:comment', DELETE_prayerRequestComment);
+
+
+/*****************************************************************************/
+/* Authenticate Requestor to Prayer Request | cache: request.prayerRequestID */
+/*****************************************************************************/
+apiServer.use('/api/prayer-request-edit/:prayer', (request:JwtPrayerRequest, response:Response, next:NextFunction) => authenticatePrayerRequestRequestorMiddleware(request, response, next));
+
+apiServer.get('/api/prayer-request-edit/:prayer', GET_PrayerRequestRequestorDetails);
+apiServer.patch('/api/prayer-request-edit/:prayer', PATCH_prayerRequest);
+apiServer.post('/api/prayer-request-edit/:prayer/resolved', POST_prayerRequestResolved);
+apiServer.delete('/api/prayer-request-edit/:prayer', DELETE_prayerRequest);
 
 
 /*********************************************************/
@@ -155,6 +181,8 @@ apiServer.use('/api/partner/:client', (request:JwtClientRequest, response:Respon
 apiServer.use('/api/partner/:client', (request:JwtClientRequest, response:Response, next:NextFunction) => authenticatePartnerMiddleware(request, response, next));
 
 apiServer.get('/api/partner/:client', GET_partnerProfile);
+
+apiServer.get('/api/partner/:client/prayer-request-list', GET_PrayerRequestRequestorList);
 
 
 /******************************************************/
@@ -176,6 +204,9 @@ apiServer.get('/api/user/:client', GET_userProfile);
 apiServer.patch('/api/user/:client', PATCH_userProfile);
 apiServer.delete('/api/user/:client', DELETE_userProfile);
 
+apiServer.get('/api/user/:client/prayer-request-list', GET_PrayerRequestRequestorList);
+apiServer.get('/api/user/:client/prayer-request-resolved-list', GET_PrayerRequestRequestorResolvedList);
+
 
 /******************************************************/
 /* Extract Circle Parameter | cache: request.circleID */
@@ -195,6 +226,8 @@ apiServer.delete('/api/circle/:circle/leave', DELETE_circleMember);
 apiServer.use('/api/circle/:circle', (request:JwtCircleRequest, response:Response, next:NextFunction) => authenticateCircleMembershipMiddleware(request, response, next));
 
 apiServer.get('/api/circle/:circle', GET_circle);
+
+apiServer.get('/api/circle/:circle/prayer-request-list', GET_PrayerRequestCircleList);
 
 
 /*******************************************/

--- a/1-src/services/database/database-types.mts
+++ b/1-src/services/database/database-types.mts
@@ -9,11 +9,11 @@ export interface CommandResponseType extends SQL.ResultSetHeader {
 /******************************************************************* 
 *           Database `user` Table Created: 6/25/2023 
 ********************************************************************/
-export const USER_TABLE_COLUMNS:string[] = [
-    'userID', 'firstName', 'lastName', 'displayName', 'email', 'passwordHash', 'postalCode', 'dateOfBirth', 'gender', 'isActive', 'walkLevel', 'image', 'notes'
-];
+export const USER_TABLE_COLUMNS_REQUIRED:string[] = [ 'displayName', 'email', 'passwordHash' ];
 
-export const USER_TABLE_COLUMNS_REQUIRED:string[] = [ 'displayName', 'email', 'passwordHash'];
+export const USER_TABLE_COLUMNS:string[] = [ ...USER_TABLE_COLUMNS_REQUIRED,
+    'userID', 'firstName', 'lastName', 'postalCode', 'dateOfBirth', 'gender', 'isActive', 'walkLevel', 'image', 'notes'
+];
 
 export type DATABASE_USER = { //Optional Fields for PATCH/UPDATE
     userID: number, 
@@ -48,11 +48,11 @@ export enum DATABASE_USER_ROLE_ENUM {
 /******************************************************************* 
 *           Database `circle` Table Created: 6/25/2023 
 ********************************************************************/
-export const CIRCLE_TABLE_COLUMNS:string[] = [
-    'circleID', 'leaderID', 'name', 'description', 'postalCode', 'isActive', 'inviteToken', 'image', 'notes'
-];
+export const CIRCLE_TABLE_COLUMNS_REQUIRED:string[] = [ 'leaderID', 'name' ];
 
-export const CIRCLE_TABLE_COLUMNS_REQUIRED:string[] = [ 'leaderID', 'name'];
+export const CIRCLE_TABLE_COLUMNS:string[] = [ ...CIRCLE_TABLE_COLUMNS_REQUIRED,
+    'circleID', 'description', 'postalCode', 'isActive', 'inviteToken', 'image', 'notes'
+];
 
 export type DATABASE_CIRCLE = {  //Optional Fields for PATCH/UPDATE
     circleID: number, 
@@ -75,12 +75,10 @@ export enum DATABASE_CIRCLE_STATUS_ENUM {
 /******************************************************************** 
 *      Database `circle_announcement` Table Created: 7/30/2023 
 *********************************************************************/
-export const CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS:string[] = [ 
-    'announcementID', 'circleID', 'message', 'startDate', 'endDate'
-];
+export const CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED:string[] = [ 'circleID', 'message', 'endDate' ];
 
-export const CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED:string[] = [ //
-    'circleID', 'message', 'endDate'
+export const CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS:string[] = [ ...CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED,
+    'announcementID', 'startDate'
 ];
 
 export type DATABASE_CIRCLE_ANNOUNCEMENT = {
@@ -95,12 +93,10 @@ export type DATABASE_CIRCLE_ANNOUNCEMENT = {
 /******************************************************************** 
 *      Database `prayer_request` Table Created: 8/9/2023 
 *********************************************************************/
-export const PRAYER_REQUEST_TABLE_COLUMNS:string[] = [
-    'prayerRequestID', 'requestorID', 'topic', 'description', 'isOnGoing', 'isResolved', 'tagsStringified', 'expirationDate'
-];
+export const PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED:string[] = [ 'requestorID', 'topic', 'description', 'expirationDate' ];
 
-export const PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED:string[] = [
-    'requestorID', 'topic', 'description', 'expirationDate'
+export const PRAYER_REQUEST_TABLE_COLUMNS:string[] = [ ...PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED,
+    'prayerRequestID', 'prayerCount', 'isOnGoing', 'isResolved', 'tagsStringified'
 ];
 
 export type DATABASE_PRAYER_REQUEST = {

--- a/1-src/services/database/queries/prayer-request-queries.mts
+++ b/1-src/services/database/queries/prayer-request-queries.mts
@@ -1,0 +1,370 @@
+import * as log from '../../log.mjs';
+import { query, execute, command, validateColumns, batch } from "../database.mjs";
+import { CircleListItem } from "../../../api/circle/circle-types.mjs";
+import { ProfileListItem } from "../../../api/profile/profile-types.mjs";
+import { CommandResponseType, DATABASE_CIRCLE_STATUS_ENUM, DATABASE_PRAYER_REQUEST, PRAYER_REQUEST_TABLE_COLUMNS, PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED } from "../database-types.mjs";
+import PRAYER_REQUEST, { prayerRequestParseTags } from '../../models/prayerRequestModel.mjs';
+import { PrayerRequestCommentListItem, PrayerRequestListItem } from '../../../api/prayer-request/prayer-request-types.mjs';
+
+
+/*****************************************************************************
+/*    DEFINING AND HANDLING ALL QUERIES HERE 
+/* TABLES: prayer_request, prayer_request_recipient, prayer_request_comment
+******************************************************************************/
+
+/* Prevent SQL Injection Protocol:
+* 1) Use Prepared Statements, auto escape input strings
+* 2) Validate Column Names
+* - Use execute() for Prepared Statements (inputs)
+* - Use query() for predefined Select Statements (static)
+* - Use command() for database operation (inputs)
+*/
+
+/* REQUIRED VALIDATION ONLY WHEN COLUMNS ARE INPUTS */
+const validatePrayerRequestColumns = (inputMap:Map<string, any>, includesRequired:boolean = false):boolean => 
+    validateColumns(inputMap, includesRequired, PRAYER_REQUEST_TABLE_COLUMNS, PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED);
+
+
+/***************************
+ *  PRAYER REQUEST QUERIES
+ ***************************/
+
+export const DB_SELECT_PRAYER_REQUEST = async(prayerRequestID:number):Promise<PRAYER_REQUEST> => {
+    const rows = await execute(`SELECT * FROM prayer_request WHERE prayerRequestID = ?`, [prayerRequestID]); 
+
+    if(rows.length !== 1) {
+        log.error(`DB ${rows.length ? 'MULTIPLE' : 'NONE'} PRAYER REQUESTS IDENTIFIED`, prayerRequestID, JSON.stringify(rows));
+        return new PRAYER_REQUEST(undefined);
+    }
+    
+    return new PRAYER_REQUEST(rows[0] as DATABASE_PRAYER_REQUEST); 
+}
+
+//Includes: prayer_request, requestorProfile, commentList, userRecipientList, circleRecipientList
+export const DB_SELECT_PRAYER_REQUEST_DETAIL = async(prayerRequestID:number, includeRecipientList:boolean = false):Promise<PRAYER_REQUEST> => {
+    const rows = await execute('SELECT prayer_request.*, '
+    + 'user.firstName as requestorFirstName, user.displayName as requestorDisplayName, user.image as requestorImage '
+    + 'FROM prayer_request '
+    + 'LEFT JOIN user ON user.userID = prayer_request.requestorID '
+    + 'WHERE prayer_request.prayerRequestID = ?;', [prayerRequestID]); 
+
+    if(rows.length !== 1) {
+        log.error(`DB ${rows.length ? 'MULTIPLE' : 'NONE'} PRAYER REQUESTS  IDENTIFIED BY ID`, prayerRequestID, JSON.stringify(rows));
+        return new PRAYER_REQUEST(undefined);
+    }
+    
+    const prayerRequest = new PRAYER_REQUEST(rows[0] as DATABASE_PRAYER_REQUEST); 
+    prayerRequest.requestorProfile = {userID: rows[0].requestorID, firstName: rows[0].requestorFirstName, displayName: rows[0].requestorDisplayName, image: rows[0].requestorImage};
+    prayerRequest.commentList = await DB_SELECT_PRAYER_REQUEST_COMMENT_LIST(prayerRequestID);
+
+    if(includeRecipientList) {
+        prayerRequest.userRecipientList = await DB_SELECT_USER_RECIPIENT_PRAYER_REQUEST_LIST(prayerRequestID);
+        prayerRequest.circleRecipientList = await DB_SELECT_CIRCLE_RECIPIENT_PRAYER_REQUEST_LIST(prayerRequestID);
+    }  
+
+    return prayerRequest;
+}
+
+export const DB_IS_PRAYER_REQUEST_REQUESTOR = async({prayerRequestID, userID}:{prayerRequestID:number, userID:number}):Promise<boolean> => {
+    const rows = await execute('SELECT prayerRequestID ' + 'FROM prayer_request '
+        + 'WHERE prayerRequestID = ? AND requestorID = ?;', [prayerRequestID, userID]);
+
+    return (rows.length === 1);
+}
+
+export const DB_INSERT_PRAYER_REQUEST = async(fieldMap:Map<string, any>):Promise<boolean> => {
+    //Validate Columns prior to Query
+    if(!validatePrayerRequestColumns(fieldMap)) {
+        log.db('Query Rejected: DB_INSERT_PRAYER_REQUEST; invalid column names', JSON.stringify(Array.from(fieldMap.keys())));
+        return false;
+    }
+
+    const preparedColumns:string = Array.from(fieldMap.keys()).map((key)=> `${key}`).join(', ');
+    const preparedValues:string = Array.from(fieldMap.keys()).map((key)=> `?`).join(', ');
+
+    const response:CommandResponseType = await command(`INSERT INTO prayer_request ( ${preparedColumns} ) VALUES ( ${preparedValues} );`, Array.from(fieldMap.values())); 
+    
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+//Dual operation for POST_prayerRequest; b/c can't add recipients without prayerRequestID
+export const DB_INSERT_AND_SELECT_PRAYER_REQUEST = async(fieldMap:Map<string, any>):Promise<PRAYER_REQUEST> => {
+    //First: Insert New prayer_request model
+    if(await DB_INSERT_PRAYER_REQUEST(fieldMap) === false)
+        return new PRAYER_REQUEST(undefined);
+
+    //Second: Select newly inserted prayer_request model
+    const preparedSelectColumns:string = Array.from(fieldMap.keys()).map((key)=> `${key} = ?`).join(' AND ');
+
+    const rows = await execute('SELECT prayer_request.*, ' 
+    + 'user.firstName as requestorFirstName, user.displayName as requestorDisplayName, user.image as requestorImage '
+    + 'FROM prayer_request '
+    + 'LEFT JOIN user ON user.userID = prayer_request.requestorID '
+    +`WHERE prayer_request.requestorID = ? ORDER BY createdDT DESC LIMIT 1;`, [fieldMap.get('requestorID')]); 
+
+    if(rows.length !== 1) {
+        log.db(`DB_INSERT_AND_SELECT_PRAYER_REQUEST : Failed to identify recently created prayer request`, JSON.stringify(fieldMap.entries()), JSON.stringify(rows));
+        return new PRAYER_REQUEST(undefined);
+    }
+
+    const prayerRequest = new PRAYER_REQUEST(rows[0] as DATABASE_PRAYER_REQUEST); 
+    prayerRequest.requestorProfile = {userID: rows[0].requestorID, firstName: rows[0].requestorFirstName, displayName: rows[0].requestorDisplayName, image: rows[0].requestorImage};
+    return prayerRequest; 
+}
+
+export const DB_UPDATE_PRAYER_REQUEST = async(prayerRequestID:number, fieldMap:Map<string, any>):Promise<boolean> => {
+    //Validate Columns prior to Query
+    if(!validatePrayerRequestColumns(fieldMap)) {
+        log.db('Query Rejected: DB_UPDATE_PRAYER_REQUEST; invalid column names', JSON.stringify(Array.from(fieldMap.keys())));
+        return false;
+    }
+
+    const preparedColumns:string = Array.from(fieldMap.keys()).map((key, field)=> `${key} = ?`).join(', ');
+
+    const response:CommandResponseType = await command(`UPDATE prayer_request SET ${preparedColumns} WHERE prayerRequestID = ?;`, [...Array.from(fieldMap.values()), prayerRequestID]); 
+
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+export const DB_UPDATE_INCREMENT_PRAYER_COUNT = async(prayerRequestID:number):Promise<boolean> => {
+
+    const response:CommandResponseType = await command(`UPDATE prayer_request SET prayerCount = (prayerCount + 1) WHERE prayerRequestID = ?;`, [prayerRequestID]); 
+
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+export const DB_UPDATE_RESOLVE_PRAYER_REQUEST = async(prayerRequestID:number):Promise<boolean> => {
+
+    const response:CommandResponseType = await command(`UPDATE prayer_request SET isResolved = true WHERE prayerRequestID = ?;`, [prayerRequestID]); 
+
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+export const DB_DELETE_PRAYER_REQUEST = async(prayerRequestID:number):Promise<boolean> => { //Note: Database Reinforces Key constrains
+
+    const response:CommandResponseType = await command('DELETE FROM prayer_request WHERE prayerRequestID = ?;', [prayerRequestID]);
+
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+//Clear all prayer request records for user; used when completely deleting user from system
+export const DB_DELETE_ALL_USER_PRAYER_REQUEST = async(userID:number):Promise<boolean> => {
+    log.db(`DB_DELETE_ALL_USER_PRAYER_REQUEST | Attempting to delete all prayer request records for userID: ${userID}`);
+
+    if(await command('DELETE FROM prayer_request_recipient WHERE userID = ? ;', [userID]) === undefined) {
+        log.db(`DB_DELETE_ALL_USER_PRAYER_REQUEST | Failed to delete prayer_request_recipients for userID: ${userID}`);
+        return false;
+
+    } else if(await command('DELETE FROM prayer_request_comment WHERE commenter = ? ;', [userID]) === undefined) {
+        log.db(`DB_DELETE_ALL_USER_PRAYER_REQUEST | Failed to delete comments for userID: ${userID}`);
+        return false;
+
+    } else if(await command('DELETE FROM prayer_request WHERE requestorID = ?;', [userID]) === undefined) {
+        log.db(`DB_DELETE_ALL_USER_PRAYER_REQUEST | Failed to delete prayer_requests for userID: ${userID}`);
+        return false;
+
+    } else
+        return true;
+}
+
+
+/******************************************
+ *  PRAYER REQUEST LIST QUERIES
+ ******************************************/
+
+//List for user including circle members, and leader; of all prayer requests where they are the intended recipient
+export const DB_SELECT_PRAYER_REQUEST_USER_LIST = async(userID:number):Promise<PrayerRequestListItem[]> => {
+    const rows = await execute('SELECT DISTINCT prayer_request.prayerRequestID, topic, prayerCount, tagsStringified, requestorID, '
+    + 'user.firstName as requestorFirstName, user.displayName as requestorDisplayName, user.image as requestorImage '
+    + 'FROM prayer_request '
+    + 'LEFT JOIN prayer_request_recipient ON prayer_request_recipient.prayerRequestID = prayer_request.prayerRequestID '
+    + 'LEFT JOIN user ON user.userID = prayer_request.requestorID '
+    + 'LEFT JOIN circle_user ON circle_user.circleID = prayer_request_recipient.circleID '
+    + 'LEFT JOIN circle ON circle.circleID = prayer_request_recipient.circleID '
+    + 'WHERE prayer_request_recipient.userID = ? OR circle_user.userID = ? OR circle.leaderID = ? '
+    + 'ORDER BY prayer_request.modifiedDT ASC LIMIT 30;', [userID, userID, userID]); 
+ 
+    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: prayerRequestParseTags(row.tagsStringified),
+            requestorProfile: {userID: row.requestorID, firstName: row.requestorFirstName, displayName: row.requestorDisplayName, image: row.requestorImage}}))];
+}
+
+//List for circle of all prayer requests where they are the intended recipient
+export const DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST = async(circleID:number):Promise<PrayerRequestListItem[]> => {
+    const rows = await execute('SELECT DISTINCT prayer_request.prayerRequestID, topic, prayerCount, tagsStringified, requestorID, '
+    + 'user.firstName as requestorFirstName, user.displayName as requestorDisplayName, user.image as requestorImage '
+    + 'FROM prayer_request '
+    + 'LEFT JOIN prayer_request_recipient ON prayer_request_recipient.prayerRequestID = prayer_request.prayerRequestID '
+    + 'LEFT JOIN user ON user.userID = prayer_request.requestorID '
+    + 'WHERE prayer_request_recipient.circleID = ? '
+    + 'ORDER BY prayer_request.modifiedDT ASC LIMIT 30;', [circleID]); 
+ 
+    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: prayerRequestParseTags(row.tagsStringified),
+            requestorProfile: {userID: row.requestorID, firstName: row.requestorFirstName, displayName: row.requestorDisplayName, image: row.requestorImage}}))];
+}
+
+//List of all prayer request created by user | optional filters: isResolved
+export const DB_SELECT_PRAYER_REQUEST_REQUESTOR_LIST = async(userID:number, isResolved:boolean):Promise<PrayerRequestListItem[]> => {
+    const rows = (isResolved !== undefined)
+        ? await execute('SELECT prayer_request.prayerRequestID, topic, prayerCount, tagsStringified, requestorID, '
+            + 'user.firstName as requestorFirstName, user.displayName as requestorDisplayName, user.image as requestorImage '
+            + 'FROM prayer_request '
+            + 'LEFT JOIN user ON user.userID = prayer_request.requestorID '
+            + 'WHERE requestorID = ? AND isResolved = ? '
+            + 'ORDER BY prayer_request.modifiedDT ASC LIMIT 30;', [userID, isResolved])
+        
+        : await execute('SELECT prayer_request.prayerRequestID, topic, prayerCount, tagsStringified, requestorID, '
+            + 'user.firstName as requestorFirstName, user.displayName as requestorDisplayName, user.image as requestorImage '
+            + 'FROM prayer_request '
+            + 'LEFT JOIN user ON user.userID = prayer_request.requestorID '
+            + 'WHERE requestorID = ? '
+            + 'ORDER BY prayer_request.modifiedDT ASC LIMIT 30;', [userID]); 
+ 
+    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: prayerRequestParseTags(row.tagsStringified),
+            requestorProfile: {userID: row.requestorID, firstName: row.requestorFirstName, displayName: row.requestorDisplayName, image: row.requestorImage}}))];
+}
+
+
+/*************************************
+ *  PRAYER REQUEST RECIPIENT QUERIES
+ *************************************/
+
+export const DB_SELECT_USER_RECIPIENT_PRAYER_REQUEST_LIST = async(prayerRequestID:number):Promise<ProfileListItem[]> => {
+    const rows = await execute('SELECT user.userID, user.firstName, user.displayName, user.image '
+    + 'FROM prayer_request_recipient '
+    + 'LEFT JOIN user ON user.userID = prayer_request_recipient.userID  '
+    + 'WHERE prayerRequestID = ? AND circleID IS NULL;', [prayerRequestID]); 
+ 
+    return [...rows.map(row => ({userID: row.userID, firstName: row.firstName, displayName: row.displayName, image: row.image}))];
+}
+
+export const DB_SELECT_CIRCLE_RECIPIENT_PRAYER_REQUEST_LIST = async(prayerRequestID:number):Promise<CircleListItem[]> => {
+    const rows = await execute('SELECT circle.circleID, circle.name, circle.image '
+    + 'FROM prayer_request_recipient '
+    + 'LEFT JOIN circle ON circle.circleID = prayer_request_recipient.circleID  '
+    + 'WHERE prayerRequestID = ? AND userID IS NULL;', [prayerRequestID]); 
+ 
+    return [...rows.map(row => ({circleID: row.circleID, name: row.name, image: row.image}))];
+}
+
+//Searches for userID match among: requestor, specified recipient, member or leader of circle which is an intended recipient
+export const DB_IS_RECIPIENT_PRAYER_REQUEST = async({prayerRequestID, userID}:{prayerRequestID:number, userID:number}):Promise<boolean> => {
+    const rows = await execute('SELECT prayer_request.prayerRequestID ' //search specified recipient
+    + 'FROM prayer_request '
+    + 'LEFT JOIN prayer_request_recipient ON prayer_request_recipient.prayerRequestID = prayer_request.prayerRequestID '
+    + 'LEFT JOIN circle_user ON circle_user.circleID = prayer_request_recipient.circleID '
+    + 'LEFT JOIN circle ON circle.circleID = prayer_request_recipient.circleID '
+    + 'WHERE prayer_request.prayerRequestID = ? AND ( prayer_request.requestorID = ? OR prayer_request_recipient.userID = ? OR circle_user.userID = ? OR circle.leaderID = ? );',
+    [ prayerRequestID, userID, userID, userID, userID ]);
+
+    return (rows.length > 0);
+}
+
+//Insert recipient individually
+export const DB_INSERT_USER_RECIPIENT_PRAYER_REQUEST = async({prayerRequestID, userID}:{prayerRequestID:number, userID:number}):Promise<boolean> => {
+    const response:CommandResponseType = await command(`INSERT INTO prayer_request_recipient ( prayerRequestID, userID ) VALUES ( ?, ? );`, [prayerRequestID, userID]);
+
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+//Batch Insert multiple recipients at once
+export const DB_INSERT_USER_RECIPIENT_PRAYER_REQUEST_BATCH = async({prayerRequestID, userRecipientIDList=[]}:{prayerRequestID:number, userRecipientIDList:number[]}):Promise<boolean> => {
+    const batchList = userRecipientIDList.map((userID:number) => ([prayerRequestID, userID]));
+
+    const response:boolean|undefined = await batch(`INSERT INTO prayer_request_recipient ( prayerRequestID, userID ) VALUES ? ;`, batchList);
+
+    return (response === true);
+}
+
+//Insert recipient individually
+export const DB_INSERT_CIRCLE_RECIPIENT_PRAYER_REQUEST = async({prayerRequestID, circleID}:{prayerRequestID:number, circleID:number}):Promise<boolean> => {
+    const response:CommandResponseType = await command(`INSERT INTO prayer_request_recipient ( prayerRequestID, circleID ) VALUES ( ?, ? );`, [prayerRequestID, circleID]);
+
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+export const DB_INSERT_CIRCLE_RECIPIENT_PRAYER_REQUEST_BATCH = async({prayerRequestID, circleRecipientIDList=[]}:{prayerRequestID:number, circleRecipientIDList:number[]}):Promise<boolean> => {
+    const batchList = circleRecipientIDList.map((circleID:number) => ([prayerRequestID, circleID]));
+
+    const response:boolean|undefined = await batch(`INSERT INTO prayer_request_recipient ( prayerRequestID, circleID ) VALUES ? ;`, batchList);
+
+    return (response === true);
+}
+
+export const DB_INSERT_RECIPIENT_PRAYER_REQUEST_BATCH = async({prayerRequestID, userRecipientIDList=[], circleRecipientIDList=[]}:{prayerRequestID:number, userRecipientIDList:number[], circleRecipientIDList:number[]}):Promise<boolean> => {
+    const batchList = [];
+    
+    if(userRecipientIDList.length > 0) {
+        batchList.push(...userRecipientIDList.map((userID:number) => ([prayerRequestID, userID, null])));
+    }
+
+    if(circleRecipientIDList.length > 0) {
+        batchList.push(...circleRecipientIDList.map((circleID:number) => ([prayerRequestID, null, circleID])));
+    }
+
+    const response:boolean|undefined = await batch(`INSERT INTO prayer_request_recipient ( prayerRequestID, userID, circleID ) VALUES ? ;`, batchList);
+
+    return (response === true);
+}
+
+//Delete recipient individually, all connections by recipientID, or all connections by prayerRequestID
+export const DB_DELETE_RECIPIENT_PRAYER_REQUEST = async({prayerRequestID, userID, circleID}:{prayerRequestID?:number, userID?:number, circleID?:number}):Promise<boolean> => {
+
+    const response:CommandResponseType = (prayerRequestID == undefined && userID !== undefined)
+        ? await command(`DELETE FROM prayer_request_recipient WHERE userID = ? ;`, [userID])
+        
+        : (prayerRequestID == undefined && circleID !== undefined)
+        ? await command('DELETE FROM prayer_request_recipient WHERE circleID = ? ;', [circleID])
+
+        : await command(`DELETE FROM prayer_request_recipient WHERE prayerRequestID = ? AND ( userID = ? OR circleID = ? );`, [prayerRequestID, userID || -1, circleID || -1]);
+
+    return ((response !== undefined) && (response.affectedRows >= 1));
+}
+
+//Batch Delete multiple recipients at once
+export const DB_DELETE_RECIPIENT_PRAYER_REQUEST_BATCH = async({prayerRequestID, userRecipientIDList=[], circleRecipientIDList=[]}:{prayerRequestID:number, userRecipientIDList:number[], circleRecipientIDList:number[]}):Promise<boolean> => {
+
+    const response:CommandResponseType = await command('DELETE FROM prayer_request_recipient WHERE prayerRequestID = ? AND '
+                                                    + `( ${[...userRecipientIDList.map((id) => 'userID = ?'), ...circleRecipientIDList.map((id) => 'circleID = ?')].join(' OR ')} );`,
+                                                    [prayerRequestID, ...userRecipientIDList, ...circleRecipientIDList]);
+
+    return ((response !== undefined) && (response.affectedRows > 0));
+}
+
+
+/*************************************
+ *  PRAYER REQUEST COMMENT QUERIES
+ *************************************/
+export const DB_SELECT_PRAYER_REQUEST_COMMENT_LIST = async(prayerRequestID:number):Promise<PrayerRequestCommentListItem[]> => {
+    const rows = await execute('SELECT prayer_request_comment.*, '
+    + 'user.firstName as commenterFirstName, user.displayName as commenterDisplayName, user.image as commenterImage '
+    + 'FROM prayer_request_comment '
+    + 'LEFT JOIN user ON user.userID = prayer_request_comment.commenterID '
+    + 'WHERE prayerRequestID = ? '
+    + 'ORDER BY createdDT ASC;', [prayerRequestID]); 
+ 
+    return [...rows.map(row => ({commentID: row.commentID || -1, prayerRequestID: row.prayerRequestID || -1, message: row.message || '', likeCount: row.likeCount || 0,
+            commenterProfile: {userID: row.commenterID, firstName: row.commenterFirstName, displayName: row.commenterDisplayName, image: row.commenterImage}}))];
+}
+
+export const DB_INSERT_PRAYER_REQUEST_COMMENT = async({prayerRequestID, commenterID, message}:{prayerRequestID:number, commenterID:number, message:string}):Promise<boolean> => {
+    const response:CommandResponseType = await command(`INSERT INTO prayer_request_comment ( prayerRequestID, commenterID, message ) VALUES ( ?, ?, ? );`, [prayerRequestID, commenterID, message]);
+
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+export const DB_UPDATE_INCREMENT_PRAYER_REQUEST_COMMENT_LIKE_COUNT = async(commentID:number):Promise<boolean> => {
+
+    const response:CommandResponseType = await command(`UPDATE prayer_request_comment SET likeCount = (likeCount + 1) WHERE commentID = ?;`, [commentID]); 
+
+    return ((response !== undefined) && (response.affectedRows === 1));
+}
+
+//Delete comment individually or all connections by prayerRequestID
+export const DB_DELETE_PRAYER_REQUEST_COMMENT = async({commentID, prayerRequestID}:{commentID?:number, prayerRequestID:number}):Promise<boolean> => {
+
+    const response:CommandResponseType = (commentID !== undefined) ?
+     await command('DELETE FROM prayer_request_comment WHERE commentID = ? ;', [commentID])
+     : await command('DELETE FROM prayer_request_comment WHERE prayerRequestID = ? ;', [prayerRequestID]);
+
+    return ((response !== undefined) && (response.affectedRows >= 1));
+}

--- a/1-src/services/models/Fields-Sync/circle-field-config.mts
+++ b/1-src/services/models/Fields-Sync/circle-field-config.mts
@@ -1,4 +1,5 @@
-/***** NO DEPENDENCIES - Define all types locally *****/
+/***** ONLY DEPENDENCIES - Define all types locally *****/
+import InputField, { InputType } from "./inputField.mjs";
 
 /*******************************************************
 *        CIRCLE FIELD CONFIGURATION FILE
@@ -16,79 +17,6 @@ export enum CircleStatus {
     INVITE = 'INVITE',
     REQUEST = 'REQUEST'
 }
-
-export enum InputType {
-    TEXT = 'TEXT',
-    NUMBER = 'NUMBER',
-    EMAIL = 'EMAIL',
-    PASSWORD = 'PASSWORD',
-    DATE = 'DATE',
-    SELECT_LIST = 'SELECT_LIST',
-    MULTI_SELECTION_LIST = 'MULTI_SELECTION_LIST',
-    PARAGRAPH = 'PARAGRAPH'
-}
-
-export type FieldInput = {
-    title: string,
-    field: string, 
-    value: string | undefined,
-    type: InputType,
-    required: boolean,
-    validationRegex: string,
-    validationMessage: string,
-    selectOptionList: string[] | number[]
-}
-
-export class InputField {
-    title: string;
-    field: string;
-    value: string | undefined;
-    type: InputType;
-    required: boolean;
-    unique: boolean;
-    validationRegex: RegExp;
-    validationMessage: string;
-    selectOptionList: string[];
-    displayOptionList: string[];
-
-    constructor({title, field, value, type=InputType.TEXT, required=false, unique=false, validationRegex=new RegExp(/.+/), validationMessage='Invalid Input', selectOptionList=[]} :
-        {title:string, field:string, value?:string | undefined, type?: InputType, required?:boolean, unique?:boolean, validationRegex?: RegExp, validationMessage?: string, selectOptionList?: string[]}) {
-        this.title = title;
-        this.field = field;
-        this.value = value;
-        this.type = type;
-        this.unique = unique;
-        this.required = unique || required;
-        this.validationRegex = validationRegex;
-        this.validationMessage = validationMessage;
-        this.selectOptionList = selectOptionList;
-        this.displayOptionList = makeDisplayList(selectOptionList);
-
-        //Default Handle List Validations
-        if(type == InputType.SELECT_LIST && validationRegex.source === '.+') {
-            this.validationRegex = new RegExp(selectOptionList.join("|"));
-            this.validationMessage = 'Please Select'
-        }
-    };
-
-    setValue(value: string): void {this.value = value; }
-
-    toJSON():FieldInput {
-        return {
-            title: this.title,
-            field: this.field,
-            value: this.value || '',
-            type: this.type,
-            required: this.required,
-            validationRegex: this.validationRegex.source,
-            validationMessage: this.validationMessage,
-            selectOptionList: this.selectOptionList
-        };
-    }
-}
-
-//Converts underscores to spaces and capitalizes each word
-export const makeDisplayList = (list:string[]):string[] => list.map(value => value.toLowerCase().split('_'||' ').map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join(' '));
 
 export const getDateDaysFuture = (days: number = 14):Date => {
     let date = new Date();

--- a/1-src/services/models/Fields-Sync/inputField.mts
+++ b/1-src/services/models/Fields-Sync/inputField.mts
@@ -1,0 +1,83 @@
+/***** NO DEPENDENCIES - Define all types locally *****/
+
+/*******************************************************
+*                    INPUT FIELD                       *
+* Sync across all repositories: server, portal, mobile *
+********************************************************/
+
+export enum InputType {
+    TEXT = 'TEXT',
+    NUMBER = 'NUMBER',
+    EMAIL = 'EMAIL',
+    PASSWORD = 'PASSWORD',
+    DATE = 'DATE',
+    SELECT_LIST = 'SELECT_LIST',
+    MULTI_SELECTION_LIST = 'MULTI_SELECTION_LIST',
+    PARAGRAPH = 'PARAGRAPH',
+    USER_ID_LIST = 'USER_ID_LIST',        //Indicate fetch & display user contact list
+    CIRCLE_ID_LIST = 'CIRCLE_ID_LIST',    //Indicate fetch & display circle membership list
+}
+
+export const isListType = (type:InputType):boolean => ((type === InputType.MULTI_SELECTION_LIST) || (type === InputType.USER_ID_LIST) || (type === InputType.CIRCLE_ID_LIST));
+
+export type FieldInput = {
+    title: string,
+    field: string, 
+    value: string | undefined,
+    type: InputType,
+    required: boolean,
+    validationRegex: string,
+    validationMessage: string,
+    selectOptionList: string[] | number[]
+}
+
+export default class InputField {
+    title: string;
+    field: string;
+    value: string | undefined;
+    type: InputType;
+    required: boolean;
+    unique: boolean;
+    validationRegex: RegExp;
+    validationMessage: string;
+    selectOptionList: string[];
+    displayOptionList: string[];
+
+    constructor({title, field, value, type=InputType.TEXT, required=false, unique=false, validationRegex=new RegExp(/.+/), validationMessage='Invalid Input', selectOptionList=[]} :
+        {title:string, field:string, value?:string | undefined, type?: InputType, required?:boolean, unique?:boolean, validationRegex?: RegExp, validationMessage?: string, selectOptionList?: string[]}) {
+        this.title = title;
+        this.field = field;
+        this.value = value;
+        this.type = type;
+        this.unique = unique;
+        this.required = unique || required;
+        this.validationRegex = validationRegex;
+        this.validationMessage = validationMessage;
+        this.selectOptionList = selectOptionList;
+        this.displayOptionList = makeDisplayList(selectOptionList);
+
+        //Default Handle List Validations
+        if(type == InputType.SELECT_LIST && validationRegex.source === '.+') {
+            this.validationRegex = new RegExp(selectOptionList.join("|"));
+            this.validationMessage = 'Please Select'
+        }
+    };
+
+    setValue(value: string): void {this.value = value; }
+
+    toJSON():FieldInput {
+        return {
+            title: this.title,
+            field: this.field,
+            value: this.value || '',
+            type: this.type,
+            required: this.required,
+            validationRegex: this.validationRegex.source,
+            validationMessage: this.validationMessage,
+            selectOptionList: this.selectOptionList
+        };
+    }
+}
+
+//Converts underscores to spaces and capitalizes each word
+export const makeDisplayList = (list:string[]):string[] => list.map(value => value.toLowerCase().split('_'||' ').map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join(' '));

--- a/1-src/services/models/Fields-Sync/prayer-request-field-config.mts
+++ b/1-src/services/models/Fields-Sync/prayer-request-field-config.mts
@@ -1,0 +1,131 @@
+/***** NO DEPENDENCIES - Define all types locally *****/
+
+/*******************************************************
+*        PRAYER REQUEST FIELD CONFIGURATION FILE
+* Sync across all repositories: server, portal
+*******************************************************/
+export const DATE_REGEX = new RegExp(/^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)$/); //1970-01-01T00:00:00.013Z
+    
+/***************************************
+*    PRAYER REQUEST TYPES AND DEPENDENCIES
+****************************************/
+//Note: enums must have matching values to cast (string as Enum) or define (Enum[string]) equally
+export enum PrayerRequestTagEnum { //List doesn't sync with database; stored as list of strings stringified as `tagsStringified`
+    SELF = 'SELF',
+    FAMILY = 'FAMILY',
+    SCHOOL = 'SCHOOL',
+    HEALING = 'HEALING',
+    PRAISE = 'PRAISE',
+    GLOBAL = 'GLOBAL'
+}
+
+export enum InputType {
+    TEXT = 'TEXT',
+    NUMBER = 'NUMBER',
+    EMAIL = 'EMAIL',
+    PASSWORD = 'PASSWORD',
+    DATE = 'DATE',
+    SELECT_LIST = 'SELECT_LIST',
+    MULTI_SELECTION_LIST = 'MULTI_SELECTION_LIST',
+    PARAGRAPH = 'PARAGRAPH'
+}
+
+export type FieldInput = {
+    title: string,
+    field: string, 
+    value: string | undefined,
+    type: InputType,
+    required: boolean,
+    validationRegex: string,
+    validationMessage: string,
+    selectOptionList: string[] | number[]
+}
+
+export class InputField {
+    title: string;
+    field: string;
+    value: string | undefined;
+    type: InputType;
+    required: boolean;
+    unique: boolean;
+    validationRegex: RegExp;
+    validationMessage: string;
+    selectOptionList: string[];
+    displayOptionList: string[];
+
+    constructor({title, field, value, type=InputType.TEXT, required=false, unique=false, validationRegex=new RegExp(/.+/), validationMessage='Invalid Input', selectOptionList=[]} :
+        {title:string, field:string, value?:string | undefined, type?: InputType, required?:boolean, unique?:boolean, validationRegex?: RegExp, validationMessage?: string, selectOptionList?: string[]}) {
+        this.title = title;
+        this.field = field;
+        this.value = value;
+        this.type = type;
+        this.unique = unique;
+        this.required = unique || required;
+        this.validationRegex = validationRegex;
+        this.validationMessage = validationMessage;
+        this.selectOptionList = selectOptionList;
+        this.displayOptionList = makeDisplayList(selectOptionList);
+
+        //Default Handle List Validations
+        if(type == InputType.SELECT_LIST && validationRegex.source === '.+') {
+            this.validationRegex = new RegExp(selectOptionList.join("|"));
+            this.validationMessage = 'Please Select'
+        }
+    };
+
+    setValue(value: string): void {this.value = value; }
+
+    toJSON():FieldInput {
+        return {
+            title: this.title,
+            field: this.field,
+            value: this.value || '',
+            type: this.type,
+            required: this.required,
+            validationRegex: this.validationRegex.source,
+            validationMessage: this.validationMessage,
+            selectOptionList: this.selectOptionList
+        };
+    }
+}
+
+//Converts underscores to spaces and capitalizes each word
+export const makeDisplayList = (list:string[]):string[] => list.map(value => value.toLowerCase().split('_'||' ').map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join(' '));
+
+export const getDateDaysFuture = (days: number = 14):Date => {
+    let date = new Date();
+    date.setDate(date.getDate() + days);
+    return date;
+}
+
+/*********************************************************************************
+*   FIELD LISTS: CREATE | EDIT =>  Used for dynamic display 
+**********************************************************************************/
+
+export const CREATE_REQUEST_FIELDS:InputField[] = [
+    new InputField({title: 'Topic', field: 'topic', required: true, type: InputType.TEXT, validationRegex: new RegExp(/.{1,30}/), validationMessage: 'Required, max 30 characters.' }),
+    new InputField({title: 'Description', field: 'description', required: true, type: InputType.PARAGRAPH, validationRegex: new RegExp(/.{0,200}/), validationMessage: 'Max 200 characters.'}),
+    new InputField({title: 'Long Term', field: 'isOnGoing', value: 'false', type: InputType.SELECT_LIST, selectOptionList: ['true', 'false']}),
+    new InputField({title: 'Category', field: 'tagList', type: InputType.MULTI_SELECTION_LIST, selectOptionList: Object.values(PrayerRequestTagEnum)}),
+    new InputField({title: 'Relevance', field: 'expirationDate', required: true, type: InputType.DATE, value: getDateDaysFuture().toISOString(), validationRegex: DATE_REGEX, validationMessage: 'Required, must be future date.' })
+    //addUserRecipientIDList:number[]
+    //addCircleRecipientIDList:number[]
+];
+
+export const EDIT_PRAYER_REQUEST_FIELDS:InputField[] = [
+    new InputField({title: 'Resolved', field: 'isResolved', value: 'false', type: InputType.SELECT_LIST, selectOptionList: ['true', 'false']}),
+    ...CREATE_REQUEST_FIELDS,
+    //addUserRecipientIDList:number[]
+    //addCircleRecipientIDList:number[]
+    //removeUserRecipientIDList:number[]
+    //removeCircleRecipientIDList:number[]
+];
+
+export const PRAYER_REQUEST_FIELDS_ADMIN:InputField[] = [
+    ...EDIT_PRAYER_REQUEST_FIELDS,
+    new InputField({title: 'Prayer Count', field: 'prayerCount', type: InputType.NUMBER})
+];
+
+export const PRAYER_REQUEST_COMMENT_FIELDS:InputField[] = [
+    new InputField({title: 'Comment', field: 'message',  required: true, type: InputType.TEXT, validationRegex: new RegExp(/.{10,200}/), validationMessage: 'Required, max 200 characters.' }),
+];

--- a/1-src/services/models/Fields-Sync/prayer-request-field-config.mts
+++ b/1-src/services/models/Fields-Sync/prayer-request-field-config.mts
@@ -1,16 +1,19 @@
-/***** NO DEPENDENCIES - Define all types locally *****/
+/***** ONLY DEPENDENCIES - Define all types locally *****/
+import InputField, { InputType } from "./inputField.mjs";
 
-/*******************************************************
-*        PRAYER REQUEST FIELD CONFIGURATION FILE
-* Sync across all repositories: server, portal
-*******************************************************/
+/***********************************************
+*   PRAYER REQUEST FIELD CONFIGURATION FILE    *
+* Sync across all repositories: server, portal *
+************************************************/
 export const DATE_REGEX = new RegExp(/^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)$/); //1970-01-01T00:00:00.013Z
     
-/***************************************
-*    PRAYER REQUEST TYPES AND DEPENDENCIES
-****************************************/
+/****************************************
+*  PRAYER REQUEST TYPES AND DEPENDENCIES
+*****************************************/
 //Note: enums must have matching values to cast (string as Enum) or define (Enum[string]) equally
-export enum PrayerRequestTagEnum { //List doesn't sync with database; stored as list of strings stringified as `tagsStringified`
+
+//List doesn't sync with database; stored as list of strings stringified as `tagsStringified`
+export enum PrayerRequestTagEnum { 
     SELF = 'SELF',
     FAMILY = 'FAMILY',
     SCHOOL = 'SCHOOL',
@@ -18,79 +21,6 @@ export enum PrayerRequestTagEnum { //List doesn't sync with database; stored as 
     PRAISE = 'PRAISE',
     GLOBAL = 'GLOBAL'
 }
-
-export enum InputType {
-    TEXT = 'TEXT',
-    NUMBER = 'NUMBER',
-    EMAIL = 'EMAIL',
-    PASSWORD = 'PASSWORD',
-    DATE = 'DATE',
-    SELECT_LIST = 'SELECT_LIST',
-    MULTI_SELECTION_LIST = 'MULTI_SELECTION_LIST',
-    PARAGRAPH = 'PARAGRAPH'
-}
-
-export type FieldInput = {
-    title: string,
-    field: string, 
-    value: string | undefined,
-    type: InputType,
-    required: boolean,
-    validationRegex: string,
-    validationMessage: string,
-    selectOptionList: string[] | number[]
-}
-
-export class InputField {
-    title: string;
-    field: string;
-    value: string | undefined;
-    type: InputType;
-    required: boolean;
-    unique: boolean;
-    validationRegex: RegExp;
-    validationMessage: string;
-    selectOptionList: string[];
-    displayOptionList: string[];
-
-    constructor({title, field, value, type=InputType.TEXT, required=false, unique=false, validationRegex=new RegExp(/.+/), validationMessage='Invalid Input', selectOptionList=[]} :
-        {title:string, field:string, value?:string | undefined, type?: InputType, required?:boolean, unique?:boolean, validationRegex?: RegExp, validationMessage?: string, selectOptionList?: string[]}) {
-        this.title = title;
-        this.field = field;
-        this.value = value;
-        this.type = type;
-        this.unique = unique;
-        this.required = unique || required;
-        this.validationRegex = validationRegex;
-        this.validationMessage = validationMessage;
-        this.selectOptionList = selectOptionList;
-        this.displayOptionList = makeDisplayList(selectOptionList);
-
-        //Default Handle List Validations
-        if(type == InputType.SELECT_LIST && validationRegex.source === '.+') {
-            this.validationRegex = new RegExp(selectOptionList.join("|"));
-            this.validationMessage = 'Please Select'
-        }
-    };
-
-    setValue(value: string): void {this.value = value; }
-
-    toJSON():FieldInput {
-        return {
-            title: this.title,
-            field: this.field,
-            value: this.value || '',
-            type: this.type,
-            required: this.required,
-            validationRegex: this.validationRegex.source,
-            validationMessage: this.validationMessage,
-            selectOptionList: this.selectOptionList
-        };
-    }
-}
-
-//Converts underscores to spaces and capitalizes each word
-export const makeDisplayList = (list:string[]):string[] => list.map(value => value.toLowerCase().split('_'||' ').map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join(' '));
 
 export const getDateDaysFuture = (days: number = 14):Date => {
     let date = new Date();
@@ -107,25 +37,25 @@ export const CREATE_REQUEST_FIELDS:InputField[] = [
     new InputField({title: 'Description', field: 'description', required: true, type: InputType.PARAGRAPH, validationRegex: new RegExp(/.{0,200}/), validationMessage: 'Max 200 characters.'}),
     new InputField({title: 'Long Term', field: 'isOnGoing', value: 'false', type: InputType.SELECT_LIST, selectOptionList: ['true', 'false']}),
     new InputField({title: 'Category', field: 'tagList', type: InputType.MULTI_SELECTION_LIST, selectOptionList: Object.values(PrayerRequestTagEnum)}),
-    new InputField({title: 'Relevance', field: 'expirationDate', required: true, type: InputType.DATE, value: getDateDaysFuture().toISOString(), validationRegex: DATE_REGEX, validationMessage: 'Required, must be future date.' })
-    //addUserRecipientIDList:number[]
-    //addCircleRecipientIDList:number[]
+    new InputField({title: 'Relevance', field: 'expirationDate', required: true, type: InputType.DATE, value: getDateDaysFuture().toISOString(), validationRegex: DATE_REGEX, validationMessage: 'Required, must be future date.' }),
+    new InputField({title: 'Send to Contacts', field: 'addUserRecipientIDList', type: InputType.USER_ID_LIST, validationRegex: new RegExp(/[0-9]+/)}),
+    new InputField({title: 'Send to Circles', field: 'addCircleRecipientIDList', type: InputType.CIRCLE_ID_LIST, validationRegex: new RegExp(/[0-9]+/)}),
 ];
 
 export const EDIT_PRAYER_REQUEST_FIELDS:InputField[] = [
     new InputField({title: 'Resolved', field: 'isResolved', value: 'false', type: InputType.SELECT_LIST, selectOptionList: ['true', 'false']}),
     ...CREATE_REQUEST_FIELDS,
-    //addUserRecipientIDList:number[]
-    //addCircleRecipientIDList:number[]
-    //removeUserRecipientIDList:number[]
-    //removeCircleRecipientIDList:number[]
+    new InputField({title: 'Send to Contacts', field: 'addUserRecipientIDList', type: InputType.USER_ID_LIST, validationRegex: new RegExp(/[0-9]+/)}),
+    new InputField({title: 'Remove Contacts', field: 'removeUserRecipientIDList', type: InputType.USER_ID_LIST, validationRegex: new RegExp(/[0-9]+/)}),
+    new InputField({title: 'Send to Circles', field: 'addCircleRecipientIDList', type: InputType.CIRCLE_ID_LIST, validationRegex: new RegExp(/[0-9]+/)}),
+    new InputField({title: 'Remove Circles', field: 'removeCircleRecipientIDList', type: InputType.CIRCLE_ID_LIST, validationRegex: new RegExp(/[0-9]+/)})
 ];
 
 export const PRAYER_REQUEST_FIELDS_ADMIN:InputField[] = [
     ...EDIT_PRAYER_REQUEST_FIELDS,
-    new InputField({title: 'Prayer Count', field: 'prayerCount', type: InputType.NUMBER})
+    new InputField({title: 'Prayer Count', field: 'prayerCount', type: InputType.NUMBER, validationRegex: new RegExp(/[0-9]+/)})
 ];
 
 export const PRAYER_REQUEST_COMMENT_FIELDS:InputField[] = [
-    new InputField({title: 'Comment', field: 'message',  required: true, type: InputType.TEXT, validationRegex: new RegExp(/.{10,200}/), validationMessage: 'Required, max 200 characters.' }),
+    new InputField({title: 'Comment', field: 'message',  required: true, type: InputType.TEXT, validationRegex: new RegExp(/.{10,200}/), validationMessage: 'Required, 10-200 characters.' }),
 ];

--- a/1-src/services/models/Fields-Sync/profile-field-config.mts
+++ b/1-src/services/models/Fields-Sync/profile-field-config.mts
@@ -1,4 +1,5 @@
-/***** NO DEPENDENCIES - Define all types locally *****/
+/***** ONLY DEPENDENCIES - Define all types locally *****/
+import InputField, { InputType } from "./inputField.mjs";
 
 /*******************************************************
 *        PROFILE FIELD CONFIGURATION FILE
@@ -26,76 +27,6 @@ export enum RoleEnum {
     ADMIN = 'ADMIN',                           //All access and privileges.
 }
 
-export enum InputType {
-    TEXT = 'TEXT',
-    NUMBER = 'NUMBER',
-    EMAIL = 'EMAIL',
-    PASSWORD = 'PASSWORD',
-    DATE = 'DATE',
-    SELECT_LIST = 'SELECT_LIST',
-    MULTI_SELECTION_LIST = 'MULTI_SELECTION_LIST',
-    PARAGRAPH = 'PARAGRAPH'
-}
-
-export type FieldInput = {
-    title: string,
-    field: string, 
-    value: string | undefined,
-    type: InputType,
-    required: boolean,
-    validationRegex: string,
-    validationMessage: string,
-    selectOptionList: string[] | number[]
-}
-
-export class InputField {
-    title: string;
-    field: string;
-    value: string | undefined;
-    type: InputType;
-    required: boolean;
-    unique: boolean;
-    validationRegex: RegExp;
-    validationMessage: string;
-    selectOptionList: string[];
-    displayOptionList: string[];
-
-    constructor({title, field, value, type=InputType.TEXT, required=false, unique=false, validationRegex=new RegExp(/.+/), validationMessage='Invalid Input', selectOptionList=[]} :
-        {title:string, field:string, value?:string | undefined, type?: InputType, required?:boolean, unique?:boolean, validationRegex?: RegExp, validationMessage?: string, selectOptionList?: string[]}) {
-        this.title = title;
-        this.field = field;
-        this.value = value;
-        this.type = type;
-        this.unique = unique;
-        this.required = unique || required;
-        this.validationRegex = validationRegex;
-        this.validationMessage = validationMessage;
-        this.selectOptionList = selectOptionList;
-        this.displayOptionList = makeDisplayList(selectOptionList);
-
-        //Default Handle List Validations
-        if(type == InputType.SELECT_LIST && validationRegex.source === '.+') {
-            this.validationRegex = new RegExp(selectOptionList.join("|"));
-            this.validationMessage = 'Please Select'
-        }
-    };
-
-    setValue(value: string): void {this.value = value; }
-
-    toJSON():FieldInput {
-        return {
-            title: this.title,
-            field: this.field,
-            value: this.value || '',
-            type: this.type,
-            required: this.required,
-            validationRegex: this.validationRegex.source,
-            validationMessage: this.validationMessage,
-            selectOptionList: this.selectOptionList
-        };
-    }
-}
-
 export const getDateYearsAgo = (years: number = 13):Date => {
     let date = new Date();
     date.setFullYear(date.getFullYear() - years);
@@ -106,9 +37,6 @@ export const getDateYearsAgo = (years: number = 13):Date => {
 export const getShortDate = (dateISO:string):string => dateISO ? dateISO.split('T')[0] : getDateYearsAgo(13).toISOString().toString().split('T')[0];
 export const getDOBMinDate = (role:RoleEnum = RoleEnum.STUDENT):Date => (role === RoleEnum.STUDENT) ? getDateYearsAgo(19) : getDateYearsAgo(100); //Max Age
 export const getDOBMaxDate = (role:RoleEnum = RoleEnum.STUDENT):Date => (role === RoleEnum.STUDENT) ? getDateYearsAgo(13) : getDateYearsAgo(18); //Min Age
-
-//Converts underscores to spaces and capitalizes each word
-export const makeDisplayList = (list:string[]):string[] => list.map(value => value.toLowerCase().split('_'||' ').map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join(' '));
 
 /*****************************************
 *   FIELD LISTS: LOGIN | SIGNUP | EDIT

--- a/1-src/services/models/baseModel.mts
+++ b/1-src/services/models/baseModel.mts
@@ -1,5 +1,5 @@
 import { JwtRequest } from "../../api/auth/auth-types.mjs";
-import { InputField } from "./Fields-Sync/profile-field-config.mjs";
+import InputField from "./Fields-Sync/inputField.mjs";
 
 /**********************************
    Base Model for Data Structure 

--- a/1-src/services/models/circleAnnouncementModel.mts
+++ b/1-src/services/models/circleAnnouncementModel.mts
@@ -1,6 +1,6 @@
 import * as log from "../log.mjs";
 import BASE_MODEL from "./baseModel.mjs";
-import { InputField, InputType } from "./Fields-Sync/circle-field-config.mjs";
+import InputField, { InputType } from "./Fields-Sync/inputField.mjs";
 import { CircleAnnouncementCreateRequest } from "../../api/circle/circle-types.mjs";
 import { DATABASE_CIRCLE_ANNOUNCEMENT, CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED } from "../database/database-types.mjs";
 

--- a/1-src/services/models/circleModel.mts
+++ b/1-src/services/models/circleModel.mts
@@ -5,6 +5,7 @@ import { CircleEditRequest, CircleEventListItem, CircleListItem } from "../../ap
 import { ProfileListItem } from "../../api/profile/profile-types.mjs";
 import { DATABASE_CIRCLE, CIRCLE_TABLE_COLUMNS } from "../database/database-types.mjs";
 import CIRCLE_ANNOUNCEMENT from "./circleAnnouncementModel.mjs";
+import { PrayerRequestListItem } from "../../api/prayer-request/prayer-request-types.mjs";
 
 /*******************************************
   UNIVERSAl circle for DATABASE OPERATIONS 
@@ -37,6 +38,7 @@ export default class CIRCLE implements BASE_MODEL  {
     leaderProfile?: ProfileListItem;
     announcementList: CIRCLE_ANNOUNCEMENT[] = [];
     eventList: CircleEventListItem[] = [];
+    prayerRequestList: PrayerRequestListItem[] = [];
     memberList: ProfileListItem[] = [];
     pendingRequestList: ProfileListItem[] = [];
     pendingInviteList: ProfileListItem[] = [];

--- a/1-src/services/models/circleModel.mts
+++ b/1-src/services/models/circleModel.mts
@@ -1,6 +1,7 @@
 import * as log from "../log.mjs";
 import BASE_MODEL from "./baseModel.mjs";
-import { CircleStatus, InputField } from "./Fields-Sync/circle-field-config.mjs";
+import InputField from "./Fields-Sync/inputField.mjs";
+import { CircleStatus } from "./Fields-Sync/circle-field-config.mjs";
 import { CircleEditRequest, CircleEventListItem, CircleListItem } from "../../api/circle/circle-types.mjs";
 import { ProfileListItem } from "../../api/profile/profile-types.mjs";
 import { DATABASE_CIRCLE, CIRCLE_TABLE_COLUMNS } from "../database/database-types.mjs";

--- a/1-src/services/models/createModelFromJson.mts
+++ b/1-src/services/models/createModelFromJson.mts
@@ -73,7 +73,7 @@ export default ({currentModel: currentModel, jsonObj, fieldList, next}:{currentM
     for(let field of fieldList) {
         if(field.required && jsonObj[field.field] === undefined && currentModel[getJsonToModelFieldMapping(currentModel, field.field)] === undefined ) {
             if(next !== undefined)
-                next(new Exception(400, `${field.title} is Required.`, `${field.title} is Required.`));
+                next(new Exception(400, `${model.modelType} | ${field.title} is Required.`, `${field.title} is Required.`));
             return undefined;
 
         } else if(jsonObj[field.field] === undefined) {
@@ -86,10 +86,10 @@ export default ({currentModel: currentModel, jsonObj, fieldList, next}:{currentM
 
         const modelValidateResult:boolean|undefined = model.validateModelSpecificField({field, value: jsonObj[field.field]});
         if(modelValidateResult === false) {
-            log.warn(`${field.title} failed model specific validations for ${model.modelType}.`);
+            log.warn(`${model.modelType} | ${field.field} failed model specific validations.`);
 
         } else if(modelValidateResult === undefined && validateInput({field, value: jsonObj[field.field], jsonObj}) === false) {
-            log.warn(`${field.title} failed field-config validations.`);
+            log.warn(`${model.modelType} | ${field.field} failed field-config validations.`);
 
         } else {
             try {
@@ -108,7 +108,7 @@ export default ({currentModel: currentModel, jsonObj, fieldList, next}:{currentM
                 model[field.field] = undefined;
 
                 if(field.required && next !== undefined) {
-                    next(new Exception(500, `${field.title} is Required; but failed to parse.`, `${field.title} Failed.`));
+                    next(new Exception(500, `${model.modelType} | ${field.title} is Required; but failed to parse.`, `${field.title} Failed.`));
                     return undefined;
                 }                
             }
@@ -117,7 +117,7 @@ export default ({currentModel: currentModel, jsonObj, fieldList, next}:{currentM
 
         if(field.required) {
             if(next !== undefined)
-                next(new Exception(400, `${field.title} input failed to validate.`, `${field.title} is invalid and required.`));
+                next(new Exception(400, `${model.modelType} | ${field.title} input failed to validate.`, `${field.title} is invalid and required.`));
             return undefined;
         }
     }

--- a/1-src/services/models/createModelFromJson.mts
+++ b/1-src/services/models/createModelFromJson.mts
@@ -7,12 +7,13 @@ import BASE_MODEL from "./baseModel.mjs";
 import { JwtClientRequest } from "../../api/auth/auth-types.mjs";
 import { Exception } from '../../api/api-types.mjs';
 import CIRCLE_ANNOUNCEMENT from './circleAnnouncementModel.mjs';
+import PRAYER_REQUEST from './prayerRequestModel.mjs';
 
 
 /**********************************************************
  * PRIVATE : Local Model Types and constructor
  **********************************************************/
-type ModelTypes = BASE_MODEL | USER | CIRCLE | CIRCLE_ANNOUNCEMENT;
+type ModelTypes = BASE_MODEL | USER | CIRCLE | CIRCLE_ANNOUNCEMENT | PRAYER_REQUEST;
 
 const getNewModel = (existingModel:BASE_MODEL):ModelTypes|undefined => {
     if(existingModel !== undefined)
@@ -27,6 +28,9 @@ const getNewModel = (existingModel:BASE_MODEL):ModelTypes|undefined => {
 
             case 'CIRCLE_ANNOUNCEMENT':
                 return new CIRCLE_ANNOUNCEMENT(undefined);
+
+            case 'PRAYER_REQUEST':
+                return new PRAYER_REQUEST(undefined, (existingModel as PRAYER_REQUEST).prayerRequestID);
 
             default:
                 log.error('createModelFromJson.getNewModel | modelType not defined', existingModel.modelType);

--- a/1-src/services/models/prayerRequestModel.mts
+++ b/1-src/services/models/prayerRequestModel.mts
@@ -2,7 +2,8 @@ import * as log from "../log.mjs";
 import BASE_MODEL from "./baseModel.mjs";
 import { ProfileListItem } from "../../api/profile/profile-types.mjs";
 import { DATABASE_PRAYER_REQUEST, PRAYER_REQUEST_TABLE_COLUMNS } from "../database/database-types.mjs";
-import { InputField, PrayerRequestTagEnum } from "./Fields-Sync/prayer-request-field-config.mjs";
+import InputField from "./Fields-Sync/inputField.mjs";
+import { PrayerRequestTagEnum } from "./Fields-Sync/prayer-request-field-config.mjs";
 import { PrayerRequestCommentListItem, PrayerRequestListItem, PrayerRequestPostRequest } from "../../api/prayer-request/prayer-request-types.mjs";
 import { CircleListItem } from "../../api/circle/circle-types.mjs";
 
@@ -16,7 +17,8 @@ export default class PRAYER_REQUEST implements BASE_MODEL  {
     isValid: boolean = false;
 
     //Private static list of class property fields | (This is display-responses; NOT edit-access.)
-    #propertyList = [ 'prayerRequestID', 'requestorID', 'topic', 'description', 'prayerCount', 'isOnGoing', 'isResolved', 'tagList', 'expirationDate', 'commentList', 'userRecipientList', 'circleRecipientList'];
+    #displayPropertyList = [ 'prayerRequestID', 'requestorID', 'topic', 'description', 'prayerCount', 'isOnGoing', 'isResolved', 'tagList', 'expirationDate', 'commentList', 'userRecipientList', 'circleRecipientList' ];
+    #propertyList = [ ...this.#displayPropertyList, 'addUserRecipientIDList', 'removeUserRecipientIDList', 'addCircleRecipientIDList', 'removeCircleRecipientIDList' ];
 
     prayerRequestID: number = -1;
     requestorID: number;
@@ -33,6 +35,12 @@ export default class PRAYER_REQUEST implements BASE_MODEL  {
     userRecipientList: ProfileListItem[] = [];
     circleRecipientList: CircleListItem[] = [];
     commentList: PrayerRequestCommentListItem[] = [];
+
+    //Temporary for JSON Patch Request
+    addUserRecipientIDList: number[];
+    removeUserRecipientIDList: number[];
+    addCircleRecipientIDList: number[];
+    removeCircleRecipientIDList: number[];
 
     constructor(DB?:DATABASE_PRAYER_REQUEST, prayerRequestID?:number) {
         try {
@@ -59,7 +67,7 @@ export default class PRAYER_REQUEST implements BASE_MODEL  {
     /* PROPERTY FIELD UTILITIES */
     hasProperty = (field:string) => this.#propertyList.includes(field);
 
-    getValidProperties = (properties:string[] = this.#propertyList, includePrayerRequestID:boolean = true):Map<string, any> => {
+    getValidProperties = (properties:string[] = this.#displayPropertyList, includePrayerRequestID:boolean = true):Map<string, any> => {
         const map = new Map<string, any>();
         properties.filter((p) => (includePrayerRequestID || (p !== 'prayerRequestID'))).forEach((field) => {
             if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null

--- a/1-src/services/models/prayerRequestModel.mts
+++ b/1-src/services/models/prayerRequestModel.mts
@@ -1,0 +1,133 @@
+import * as log from "../log.mjs";
+import BASE_MODEL from "./baseModel.mjs";
+import { ProfileListItem } from "../../api/profile/profile-types.mjs";
+import { DATABASE_PRAYER_REQUEST, PRAYER_REQUEST_TABLE_COLUMNS } from "../database/database-types.mjs";
+import { InputField, PrayerRequestTagEnum } from "./Fields-Sync/prayer-request-field-config.mjs";
+import { PrayerRequestCommentListItem, PrayerRequestListItem, PrayerRequestPostRequest } from "../../api/prayer-request/prayer-request-types.mjs";
+import { CircleListItem } from "../../api/circle/circle-types.mjs";
+
+/*******************************************
+  UNIVERSAl PRAYER_REQUEST for DATABASE OPERATIONS 
+********************************************/
+export default class PRAYER_REQUEST implements BASE_MODEL  {
+    modelType = 'PRAYER_REQUEST';
+    getID = () => this.prayerRequestID;
+    setID = (id:number) => this.prayerRequestID = id;
+    isValid: boolean = false;
+
+    //Private static list of class property fields | (This is display-responses; NOT edit-access.)
+    #propertyList = [ 'prayerRequestID', 'requestorID', 'topic', 'description', 'prayerCount', 'isOnGoing', 'isResolved', 'tagList', 'expirationDate', 'commentList', 'userRecipientList', 'circleRecipientList'];
+
+    prayerRequestID: number = -1;
+    requestorID: number;
+    topic: string;
+    description: string;
+    prayerCount: number;
+    isOnGoing: boolean;
+    isResolved: boolean;
+    tagList: PrayerRequestTagEnum[] = [];
+    expirationDate: Date;
+
+    //Query separate Tables
+    requestorProfile: ProfileListItem;
+    userRecipientList: ProfileListItem[] = [];
+    circleRecipientList: CircleListItem[] = [];
+    commentList: PrayerRequestCommentListItem[] = [];
+
+    constructor(DB?:DATABASE_PRAYER_REQUEST, prayerRequestID?:number) {
+        try {
+            this.prayerRequestID = prayerRequestID || DB?.prayerRequestID || -1;
+
+            if(DB !== undefined) {
+                this.requestorID = DB.requestorID;
+                this.topic = DB.topic;
+                this.description = DB.description;
+                this.prayerCount = DB.prayerCount;
+                this.isOnGoing = DB.isOnGoing ? true : false;
+                this.isResolved = DB.isResolved ? true : false;
+                this.expirationDate = DB.expirationDate;
+
+                this.tagList = prayerRequestParseTags(DB.tagsStringified);
+                
+                this.isValid = true;
+            }
+        } catch(error) {
+            log.db('INVALID Database Object; failed to parse PRAYER_REQUEST', JSON.stringify(DB), error);
+        }
+    }
+
+    /* PROPERTY FIELD UTILITIES */
+    hasProperty = (field:string) => this.#propertyList.includes(field);
+
+    getValidProperties = (properties:string[] = this.#propertyList, includePrayerRequestID:boolean = true):Map<string, any> => {
+        const map = new Map<string, any>();
+        properties.filter((p) => (includePrayerRequestID || (p !== 'prayerRequestID'))).forEach((field) => {
+            if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
+              && (!Array.isArray(this[field]) || this[field].length > 0)) {
+                    map.set(field, this[field]);
+              }
+        });
+        return map;
+    }
+
+ 
+    getUniqueDatabaseProperties = (prayerRequest:PRAYER_REQUEST):Map<string, any> => {
+        const map = new Map<string, any>();
+        PRAYER_REQUEST_TABLE_COLUMNS.filter((c) => ((c !== 'prayerRequestID'))).forEach((field) => {
+
+            if(field === 'tagsStringified' && (JSON.stringify(Array.from(this['tagList']).sort()) !== JSON.stringify(Array.from(prayerRequest['tagList']).sort())))
+                map.set('tagsStringified', JSON.stringify(this['tagList']));
+            
+            else if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
+                && ((Array.isArray(this[field]) 
+                    && (JSON.stringify(Array.from(this[field]).sort()) !== JSON.stringify(Array.from(prayerRequest[field]).sort()))) 
+                || (this[field] !== prayerRequest[field])))
+                    map.set(field, this[field]);
+        });
+        return map;
+      }
+
+    getDatabaseProperties = ():Map<string, any> => this.getUniqueDatabaseProperties(new PRAYER_REQUEST());
+
+    toJSON = ():DATABASE_PRAYER_REQUEST => Object.fromEntries(this.getValidProperties()) as unknown as DATABASE_PRAYER_REQUEST;
+
+    toListItem = ():PrayerRequestListItem => ({prayerRequestID: this.prayerRequestID, requestorProfile: this.requestorProfile, topic: this.topic, prayerCount: this.prayerCount, tagList: this.tagList});
+
+    toString = ():string => JSON.stringify(Object.fromEntries(this.getValidProperties()));
+
+    /** Utility methods for createModelFromJSON **/
+    validateModelSpecificField = ({field, value}:{field:InputField, value:string}):boolean|undefined => {
+        //No Field Match
+        return undefined;
+    }
+
+    parseModelSpecificField = ({field, jsonObj}:{field:InputField, jsonObj:PrayerRequestPostRequest['body']}):boolean|undefined => {
+        //Handle inviteToken for security
+        if(field.field === 'tagList') {
+            Array.from(jsonObj[field.field]).forEach((item:string) => {
+                if(Object.values(PrayerRequestTagEnum).includes(PrayerRequestTagEnum[item])) 
+                    this.tagList.push(PrayerRequestTagEnum[item]);
+            });
+            return true;
+        }
+        //No Field Match
+        return undefined;
+    }
+};
+
+/* ADDITIONAL UTILITIES */
+export const prayerRequestParseTags = (tagsStringified:string):PrayerRequestTagEnum[] => {
+    const tagList = [];
+    if(tagsStringified !== undefined && tagsStringified !== null && tagsStringified.length > 0) {        
+        try {
+            const list:string[] = JSON.parse(tagsStringified);
+            list.forEach((item:string) => {
+                if(Object.values(PrayerRequestTagEnum).includes(PrayerRequestTagEnum[item])) 
+                    tagList.push(PrayerRequestTagEnum[item]);
+            });
+        } catch(error) {
+            log.error('Failed to parse prayer request tags', tagsStringified, error);
+        }
+    }
+    return tagList;
+}

--- a/1-src/services/models/userModel.mts
+++ b/1-src/services/models/userModel.mts
@@ -1,7 +1,8 @@
 import * as log from '../log.mjs';
 import { DATABASE_USER, USER_TABLE_COLUMNS } from "../database/database-types.mjs";
 import { CircleListItem } from "../../api/circle/circle-types.mjs";
-import { GenderEnum, InputField, InputType, RoleEnum, getDOBMaxDate, getDOBMinDate } from "./Fields-Sync/profile-field-config.mjs";
+import InputField, { InputType } from "./Fields-Sync/inputField.mjs";
+import { GenderEnum, RoleEnum, getDOBMaxDate, getDOBMinDate } from "./Fields-Sync/profile-field-config.mjs";
 import { ProfileListItem, ProfileResponse, ProfilePublicResponse, ProfilePartnerResponse, ProfileEditRequest } from "../../api/profile/profile-types.mjs";
 import BASE_MODEL from './baseModel.mjs';
 import { getPasswordHash } from '../../api/auth/auth-utilities.mjs';


### PR DESCRIPTION
Happy to say this one is mostly straight forward for a new features.

**Changes Includes:**

- Prayer Request Input Config | `prayer-request-field-config`
- ** Extracted "Input Type" to` inputField.mts` as only config dependancy and keep InputType consistent |` inputField.mts`
- Prayer Request Model | `prayerRequestModel.mts`
- Prayer Request & Comment Queries| `prayer-request-queries.mts`
- Prayer Request & Comment Routes | `prayer-request.mts`
- Prayer Request Authentication | `authentication.mts`

- ** Also, restructured  column list to use inheritance from required | `database-types.mts`