### PR TITLE
56 image upload routes

### DIFF
--- a/1-src/api/api-types.mts
+++ b/1-src/api/api-types.mts
@@ -1,6 +1,8 @@
 
 /*    Type Declarations     */
 
+import { JwtClientRequest } from "./auth/auth-types.mjs";
+
 export class Exception extends Error {
     status: number;
     message: string;
@@ -14,4 +16,8 @@ export class Exception extends Error {
     }
   }
 
-
+  export enum ImageTypeEnum {
+    USER_PROFILE = 'USER_PROFILE',
+    CIRCLE_PROFILE = 'CIRCLE_PROFILE',
+    CIRCLE_EVENT = 'CIRCLE_EVENT'
+  }

--- a/1-src/api/api-utilities.mts
+++ b/1-src/api/api-utilities.mts
@@ -1,4 +1,99 @@
 import { Request, Response, NextFunction } from "express";
+import {S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+import axios from 'axios';
+import * as log from '../services/log.mjs';
+import dotenv from 'dotenv';
+import { ImageTypeEnum } from "./api-types.mjs";
+import { SUPPORTED_IMAGE_EXTENSION_LIST } from "../services/models/Fields-Sync/inputField.mjs";
+dotenv.config(); 
 
   
-/* Utility Methods */
+export const getImageFileName = ({id, imageType, fileName}:{id:number, imageType:ImageTypeEnum, fileName:string}):string|undefined => {
+    const extension = fileName.split('.').pop(); //dot optional
+    if(SUPPORTED_IMAGE_EXTENSION_LIST.includes(extension)) 
+        return `${imageType.toLowerCase()}_${id}.${extension}`;
+    else {
+        log.error('Image Upload to AWS S3 with unsupported file type.', extension, fileName, imageType, id);
+        return undefined;
+    }    
+}
+
+
+export const uploadImage = async({id, imageType, fileName, imageBlob: imageBlob}:{id:number, imageType:ImageTypeEnum, fileName:string, imageBlob:Blob}):Promise<string|undefined> => {
+    const imageFileName = getImageFileName({id, imageType, fileName});
+
+    return (imageFileName === undefined) ? undefined
+        : (process.env.ENVIRONMENT === 'PRODUCTION') ? uploadImageProduction(imageFileName, imageBlob) : uploadImageDevelopment(imageFileName, imageBlob);
+}
+
+
+export const clearImage = async(fileName:string):Promise<boolean> => 
+    (process.env.ENVIRONMENT === 'PRODUCTION') ? clearImageProduction(fileName) : clearImageDevelopment(fileName);
+
+
+export const clearImageCombinations = async ({id, imageType}:{id:number, imageType:ImageTypeEnum}):Promise<boolean> =>
+    await SUPPORTED_IMAGE_EXTENSION_LIST.reduce(async(previousCall, extension) => {
+        const previousResult:boolean = await previousCall;
+        return clearImage(getImageFileName({id, imageType, fileName: extension})) || previousResult;
+    }, Promise.resolve(false));
+
+
+/* Development Environment AWS S3 Bucket Upload */
+const uploadImageDevelopment = async(fileName:string, imageBlob:Blob):Promise<string|undefined> => 
+    await axios.put(`https://3uczw0bwaj.execute-api.${process.env.IMAGE_BUCKET_REGION}.amazonaws.com/prod/${process.env.IMAGE_BUCKET_NAME}/${fileName}`,
+            imageBlob,
+            { headers: { 'x-api-key': process.env.IMAGE_BUCKET_KEY }})
+        .then((response) => {
+            log.event('Successful - Development Image Upload', fileName, response.status, response.data);
+            return `http://${process.env.IMAGE_BUCKET_NAME}.s3.amazonaws.com/${fileName}`;
+        })
+        .catch(function (error) {
+            log.event('Failed - Development Image Upload', fileName, error);
+            return undefined;
+        });
+
+
+const clearImageDevelopment = async(fileName:string):Promise<boolean> => 
+    await axios.delete(`https://3uczw0bwaj.execute-api.${process.env.IMAGE_BUCKET_REGION}.amazonaws.com/prod/${process.env.IMAGE_BUCKET_NAME}/${fileName}`,
+            { headers: { 'x-api-key': process.env.IMAGE_BUCKET_KEY }})
+        .then((response) => {
+            log.event('Successful - Development Image Delete', fileName, response.status, response.data);
+            return `http://${process.env.IMAGE_BUCKET_NAME}.s3.amazonaws.com/${fileName}`;
+        })
+        .catch(function (error) {
+            log.event('Failed - Development Image Delete', fileName, error);
+            return undefined;
+        });
+
+
+/* Development Environment AWS S3 Bucket Upload | Uses IAM authentication */
+const uploadImageProduction = async(fileName:string, imageBlog:Blob):Promise<string|undefined> => {
+    const client = new S3Client({ region: process.env.IMAGE_BUCKET_REGION });
+
+    const command = new PutObjectCommand({
+        Bucket: process.env.IMAGE_BUCKET_NAME,
+        Key: fileName,
+        Body: imageBlog
+    });
+
+    const response = await client.send(command);
+
+    log.event(response.$metadata);
+
+    return (response.$metadata.httpStatusCode > 200 && response.$metadata.httpStatusCode < 300) ? fileName : undefined;
+}
+
+const clearImageProduction = async(fileName:string):Promise<boolean> => {
+    const client = new S3Client({ region: process.env.IMAGE_BUCKET_REGION });
+
+    const command = new DeleteObjectCommand({
+        Bucket: process.env.IMAGE_BUCKET_NAME,
+        Key: fileName
+    });
+
+    const response = await client.send(command);
+
+    log.event(response.$metadata);
+
+    return (response.$metadata.httpStatusCode > 200 && response.$metadata.httpStatusCode < 300);
+}

--- a/1-src/api/api-utilities.mts
+++ b/1-src/api/api-utilities.mts
@@ -26,16 +26,17 @@ export const uploadImage = async({id, imageType, fileName, imageBlob: imageBlob}
         : (process.env.ENVIRONMENT === 'PRODUCTION') ? uploadImageProduction(imageFileName, imageBlob) : uploadImageDevelopment(imageFileName, imageBlob);
 }
 
-
+//return true for non-error responses
 export const clearImage = async(fileName:string):Promise<boolean> => 
     (process.env.ENVIRONMENT === 'PRODUCTION') ? clearImageProduction(fileName) : clearImageDevelopment(fileName);
 
 
+//Attempts all supported image extensions and return false for any error responses
 export const clearImageCombinations = async ({id, imageType}:{id:number, imageType:ImageTypeEnum}):Promise<boolean> =>
     await SUPPORTED_IMAGE_EXTENSION_LIST.reduce(async(previousCall, extension) => {
         const previousResult:boolean = await previousCall;
-        return clearImage(getImageFileName({id, imageType, fileName: extension})) || previousResult;
-    }, Promise.resolve(false));
+        return clearImage(getImageFileName({id, imageType, fileName: extension})) && previousResult;
+    }, Promise.resolve(true));
 
 
 /* Development Environment AWS S3 Bucket Upload */
@@ -44,11 +45,11 @@ const uploadImageDevelopment = async(fileName:string, imageBlob:Blob):Promise<st
             imageBlob,
             { headers: { 'x-api-key': process.env.IMAGE_BUCKET_KEY }})
         .then((response) => {
-            log.event('Successful - Development Image Upload', fileName, response.status, response.data);
+            log.event('Successful - Development S3 Image Upload', fileName, response.status, response.data);
             return `http://${process.env.IMAGE_BUCKET_NAME}.s3.amazonaws.com/${fileName}`;
         })
         .catch(function (error) {
-            log.event('Failed - Development Image Upload', fileName, error);
+            log.error('Failed - Development S3 Image Upload', fileName, error);
             return undefined;
         });
 
@@ -57,43 +58,53 @@ const clearImageDevelopment = async(fileName:string):Promise<boolean> =>
     await axios.delete(`https://3uczw0bwaj.execute-api.${process.env.IMAGE_BUCKET_REGION}.amazonaws.com/prod/${process.env.IMAGE_BUCKET_NAME}/${fileName}`,
             { headers: { 'x-api-key': process.env.IMAGE_BUCKET_KEY }})
         .then((response) => {
-            log.event('Successful - Development Image Delete', fileName, response.status, response.data);
-            return `http://${process.env.IMAGE_BUCKET_NAME}.s3.amazonaws.com/${fileName}`;
+            log.event('Successful - Development S3 Image Delete', fileName, response.status, response.data);
+            return true;
         })
         .catch(function (error) {
-            log.event('Failed - Development Image Delete', fileName, error);
-            return undefined;
+            log.error('Failed - Development S3 Image Delete', fileName, error);
+            return false;
         });
 
 
 /* Development Environment AWS S3 Bucket Upload | Uses IAM authentication */
 const uploadImageProduction = async(fileName:string, imageBlog:Blob):Promise<string|undefined> => {
-    const client = new S3Client({ region: process.env.IMAGE_BUCKET_REGION });
+    try {
+        const client = new S3Client({ region: process.env.IMAGE_BUCKET_REGION });
 
-    const command = new PutObjectCommand({
-        Bucket: process.env.IMAGE_BUCKET_NAME,
-        Key: fileName,
-        Body: imageBlog
-    });
+        const command = new PutObjectCommand({
+            Bucket: process.env.IMAGE_BUCKET_NAME,
+            Key: fileName,
+            Body: imageBlog
+        });
 
-    const response = await client.send(command);
+        const response = await client.send(command);
 
-    log.event(response.$metadata);
+        log.event('Successful - Production S3 Image Upload', fileName);
+        return fileName;
 
-    return (response.$metadata.httpStatusCode > 200 && response.$metadata.httpStatusCode < 300) ? fileName : undefined;
+    } catch(error) {
+        log.error('Failed - Production S3 Image Upload', error);
+        return undefined;
+    }
 }
 
 const clearImageProduction = async(fileName:string):Promise<boolean> => {
-    const client = new S3Client({ region: process.env.IMAGE_BUCKET_REGION });
+    try {
+        const client = new S3Client({ region: process.env.IMAGE_BUCKET_REGION });
 
-    const command = new DeleteObjectCommand({
-        Bucket: process.env.IMAGE_BUCKET_NAME,
-        Key: fileName
-    });
+        const command = new DeleteObjectCommand({
+            Bucket: process.env.IMAGE_BUCKET_NAME,
+            Key: fileName
+        });
 
-    const response = await client.send(command);
+        const response = await client.send(command);
 
-    log.event(response.$metadata);
+        log.event('Successful - Production S3 Image Delete', fileName);
+        return true;
 
-    return (response.$metadata.httpStatusCode > 200 && response.$metadata.httpStatusCode < 300);
+    } catch(error) {
+        log.error('Failed - Production S3 Image Delete', error);
+        return false;
+    }
 }

--- a/1-src/api/circle/circle-types.mts
+++ b/1-src/api/circle/circle-types.mts
@@ -72,3 +72,10 @@ export interface CircleAnnouncementCreateRequest extends JwtCircleRequest {
         EndDate: Date,
     } 
 }
+
+export interface CircleImageRequest extends JwtCircleRequest {
+    params: JwtCircleRequest['params'] & {
+        file:string
+    },
+    body: Blob
+}

--- a/1-src/api/circle/circle.mts
+++ b/1-src/api/circle/circle.mts
@@ -128,6 +128,9 @@ export const DELETE_circle =  async(request: JwtCircleRequest, response: Respons
     
     else if(await DB_DELETE_CIRCLE_USER_STATUS({userID: undefined, circleID: request.circleID}) === false)
         next(new Exception(500, `Failed to delete all user members for circle ${request.circleID}`, 'Removing Members Failed'));
+        
+    else if(await clearImageCombinations({id: request.circleID, imageType: ImageTypeEnum.CIRCLE_PROFILE}) === false)
+        next(new Exception(500, `Failed to delete circle profile image for circle ${request.circleID}`, 'Profile Image Exists'));
 
     else if(await DB_DELETE_CIRCLE(request.circleID))
         response.status(204).send(`User ${request.circleID} deleted successfully`);

--- a/1-src/api/circle/circle.mts
+++ b/1-src/api/circle/circle.mts
@@ -1,6 +1,6 @@
 import { Response, NextFunction } from 'express';
 import * as log from '../../services/log.mjs';
-import {Exception} from '../api-types.mjs'
+import {Exception, ImageTypeEnum} from '../api-types.mjs'
 import { JwtCircleClientRequest, JwtCircleRequest, JwtRequest } from '../auth/auth-types.mjs';
 import { DB_DELETE_CIRCLE, DB_DELETE_CIRCLE_ANNOUNCEMENT, DB_DELETE_CIRCLE_USER_STATUS, DB_INSERT_CIRCLE, DB_INSERT_CIRCLE_ANNOUNCEMENT, DB_INSERT_CIRCLE_USER_STATUS, DB_SELECT_ALL_CIRCLES, DB_SELECT_CIRCLE, DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT, DB_SELECT_CIRCLE_DETAIL, DB_SELECT_CIRCLE_DETAIL_BY_NAME, DB_SELECT_CIRCLE_USER_LIST, DB_SELECT_USER_CIRCLES, DB_UPDATE_CIRCLE, DB_UPDATE_CIRCLE_USER_STATUS } from '../../services/database/queries/circle-queries.mjs';
 import CIRCLE from '../../services/models/circleModel.mjs';
@@ -10,10 +10,11 @@ import createModelFromJSON from '../../services/models/createModelFromJson.mjs';
 import { DB_IS_USER_ROLE } from '../../services/database/queries/user-queries.mjs';
 import InputField from '../../services/models/Fields-Sync/inputField.mjs';
 import { CIRCLE_ANNOUNCEMENT_FIELDS, CIRCLE_FIELDS, CIRCLE_FIELDS_ADMIN, CircleStatus } from '../../services/models/Fields-Sync/circle-field-config.mjs';
-import { CircleAnnouncementCreateRequest } from './circle-types.mjs';
+import { CircleAnnouncementCreateRequest, CircleImageRequest } from './circle-types.mjs';
 import CIRCLE_ANNOUNCEMENT from '../../services/models/circleAnnouncementModel.mjs';
 import getCircleEventSampleList from './circle-event-samples.mjs';
 import { DB_DELETE_RECIPIENT_PRAYER_REQUEST, DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST } from '../../services/database/queries/prayer-request-queries.mjs';
+import { clearImage, clearImageCombinations, uploadImage } from '../api-utilities.mjs';
 
 /******************
  *  CIRCLE ROUTES
@@ -133,6 +134,32 @@ export const DELETE_circle =  async(request: JwtCircleRequest, response: Respons
     else
         next(new Exception(404, `Circle Delete Failed :: Failed to delete circle ${request.circleID}.`, 'Delete Failed'));
 };
+
+/* Circle Profile Images */
+export const GET_circleImage = async(request: JwtCircleRequest, response: Response, next: NextFunction) => {
+    const filePath:string|undefined = (await DB_SELECT_CIRCLE(request.circleID)).image || undefined;
+    if(filePath !== undefined)
+        response.status(200).redirect(filePath);
+    else
+        next(new Exception(404, `Circle ${request.circleID} doesn't have a saved profile image`, 'No Image'));
+}
+
+export const POST_circleImage = async(request: CircleImageRequest, response: Response, next: NextFunction) => {
+    const fileName:string = request.params.file || 'invalid';
+    const savedFileName:string|undefined = await uploadImage({id:request.circleID, fileName, imageBlob: request.body, imageType: ImageTypeEnum.USER_PROFILE});
+    if(savedFileName !== undefined && await DB_UPDATE_CIRCLE(request.circleID, new Map([['image', savedFileName]])))
+        response.status(202).send(`Successfully saved profile image: ${savedFileName}`);
+    else
+        next(new Exception(500, `Profile image upload failed: ${savedFileName}`, 'Upload Failed'));
+}
+
+export const DELETE_circleImage = async(request: JwtCircleRequest, response: Response, next: NextFunction) => {
+    if(await clearImageCombinations({id:request.circleID, imageType: ImageTypeEnum.CIRCLE_PROFILE}) && await DB_UPDATE_CIRCLE(request.circleID, new Map([['image', null]])))
+        response.status(202).send(`Successfully deleted circle image for ${request.circleID}`);
+    else
+        next(new Exception(500, `Circle image deletion failed for ${request.circleID}`, 'Delete Failed'));
+}
+
 
 /***********************
  *  CIRCLE ANNOUNCEMENT

--- a/1-src/api/profile/profile-types.mts
+++ b/1-src/api/profile/profile-types.mts
@@ -74,3 +74,10 @@ export interface ProfileEditRequest extends JwtClientRequest {
 export interface ProfileSignupRequest extends Request  {
     body: Request['body'] & ProfileEditRequest['body']
 }
+
+export interface ProfileImageRequest extends JwtClientRequest {
+    params: JwtClientRequest['params'] & {
+        file:string
+    }
+    body: Blob
+}

--- a/1-src/api/profile/profile.mts
+++ b/1-src/api/profile/profile.mts
@@ -147,6 +147,9 @@ export const DELETE_userProfile = async (request: JwtClientRequest, response: Re
     else if(await DB_DELETE_USER_ROLE({userID: request.clientID, userRoleList: undefined}) === false)
         next(new Exception(500, `Failed to delete all user roles of user ${request.clientID}`, 'User Roles Exists'));
 
+    else if(await clearImageCombinations({id: request.clientID, imageType: ImageTypeEnum.USER_PROFILE}) === false)
+        next(new Exception(500, `Failed to delete profile image for user ${request.clientID}`, 'Profile Image Exists'));
+
     else if(await DB_DELETE_USER(request.clientID))
         response.status(204).send(`User ${request.clientID} deleted successfully`);
     else

--- a/1-src/api/profile/profile.mts
+++ b/1-src/api/profile/profile.mts
@@ -1,10 +1,10 @@
 import express, {Router, Request, Response, NextFunction} from 'express';
 import URL, { URLSearchParams } from 'url';
 import * as log from '../../services/log.mjs';
-import {Exception} from '../api-types.mjs'
+import {Exception, ImageTypeEnum} from '../api-types.mjs'
 import { JwtClientRequest, JwtRequest } from '../auth/auth-types.mjs';
 import { isMaxRoleGreaterThan, validateNewRoleTokenList } from '../auth/auth-utilities.mjs';
-import { ProfileEditRequest } from './profile-types.mjs';
+import { ProfileEditRequest, ProfileImageRequest } from './profile-types.mjs';
 import { EDIT_PROFILE_FIELDS, EDIT_PROFILE_FIELDS_ADMIN, RoleEnum, SIGNUP_PROFILE_FIELDS, SIGNUP_PROFILE_FIELDS_STUDENT } from '../../services/models/Fields-Sync/profile-field-config.mjs';
 import { DB_DELETE_USER, DB_DELETE_USER_ROLE, DB_INSERT_USER_ROLE, DB_SELECT_CONTACTS, DB_SELECT_USER, DB_SELECT_USER_PROFILE, DB_SELECT_USER_ROLES, DB_UNIQUE_USER_EXISTS, DB_UPDATE_USER } from '../../services/database/queries/user-queries.mjs';
 import USER from '../../services/models/userModel.mjs';
@@ -12,6 +12,7 @@ import { DB_DELETE_CIRCLE_USER_STATUS, DB_SELECT_MEMBERS_OF_ALL_CIRCLES, DB_SELE
 import createModelFromJSON from '../../services/models/createModelFromJson.mjs';
 import { DATABASE_USER_ROLE_ENUM } from '../../services/database/database-types.mjs';
 import { DB_DELETE_ALL_USER_PRAYER_REQUEST, DB_DELETE_PRAYER_REQUEST } from '../../services/database/queries/prayer-request-queries.mjs';
+import { clearImage, clearImageCombinations, uploadImage } from '../api-utilities.mjs';
 
 //UI Helper Utility
 export const GET_RoleList = (request: Request, response: Response, next: NextFunction) => {
@@ -151,3 +152,31 @@ export const DELETE_userProfile = async (request: JwtClientRequest, response: Re
     else
         next(new Exception(404, `Profile Delete Failed :: Failed to delete user ${request.clientID} account.`, 'Delete Failed'));
 };
+
+/* Profile Images */
+export const GET_profileImage = async(request: JwtClientRequest, response: Response, next: NextFunction) => {
+    const filePath:string|undefined = (await DB_SELECT_USER(new Map([['userID', request.clientID]]))).image || undefined;
+    if(filePath !== undefined)
+        response.status(200).redirect(filePath);
+    else
+        next(new Exception(404, `User ${request.clientID} doesn't have a saved profile image`, 'No Image'));
+}
+
+/* Headers: Content-Type: 'image/jpg' or 'image/png' & Content-Length: (calculated) | Body: binary: Blob */
+export const POST_profileImage = async(request: ProfileImageRequest, response: Response, next: NextFunction) => {
+    const fileName:string = request.params.file || 'invalid';
+    const filePath:string|undefined = await uploadImage({id:request.clientID, fileName, imageBlob: request.body, imageType: ImageTypeEnum.USER_PROFILE});
+    
+    if(filePath !== undefined && await DB_UPDATE_USER(request.clientID, new Map([['image', filePath]])))
+        response.status(202).send(`Successfully saved profile image: ${filePath}`);
+    else
+        next(new Exception(500, `Profile image upload failed: ${filePath}`, 'Upload Failed'));
+}
+
+export const DELETE_profileImage = async(request: JwtClientRequest, response: Response, next: NextFunction) => {
+
+    if(await clearImageCombinations({id:request.clientID, imageType: ImageTypeEnum.USER_PROFILE}) && await DB_UPDATE_USER(request.clientID, new Map([['image', null]])))
+        response.status(202).send(`Successfully deleted profile image for ${request.clientID}`);
+    else
+        next(new Exception(500, `Profile image deletion failed for ${request.clientID}`, 'Delete Failed'));
+}

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -19,8 +19,8 @@ import logRoutes from './api/log/log.mjs';
 import apiRoutes from './api/api.mjs';
 
 import {GET_allUserCredentials, GET_jwtVerify, POST_login, POST_logout, POST_signup, POST_authorization_reset } from './api/auth/auth.mjs';
-import { GET_EditProfileFields, GET_partnerProfile, GET_profileAccessUserList, GET_publicProfile, GET_RoleList, GET_SignupProfileFields, GET_userProfile, PATCH_userProfile, GET_AvailableAccount, DELETE_userProfile } from './api/profile/profile.mjs';
-import { GET_publicCircle, GET_circle, POST_newCircle, DELETE_circle, DELETE_circleLeaderMember, DELETE_circleMember, PATCH_circle, POST_circleLeaderAccept, POST_circleMemberAccept, POST_circleMemberJoinAdmin, POST_circleMemberRequest, POST_circleLeaderMemberInvite, DELETE_circleAnnouncement, POST_circleAnnouncement, GET_CircleList } from './api/circle/circle.mjs';
+import { GET_EditProfileFields, GET_partnerProfile, GET_profileAccessUserList, GET_publicProfile, GET_RoleList, GET_SignupProfileFields, GET_userProfile, PATCH_userProfile, GET_AvailableAccount, DELETE_userProfile, POST_profileImage, DELETE_profileImage, GET_profileImage } from './api/profile/profile.mjs';
+import { GET_publicCircle, GET_circle, POST_newCircle, DELETE_circle, DELETE_circleLeaderMember, DELETE_circleMember, PATCH_circle, POST_circleLeaderAccept, POST_circleMemberAccept, POST_circleMemberJoinAdmin, POST_circleMemberRequest, POST_circleLeaderMemberInvite, DELETE_circleAnnouncement, POST_circleAnnouncement, GET_CircleList, POST_circleImage, DELETE_circleImage, GET_circleImage } from './api/circle/circle.mjs';
 import { DELETE_prayerRequest, DELETE_prayerRequestComment, GET_PrayerRequest, GET_PrayerRequestRequestorDetails, GET_PrayerRequestCircleList, GET_PrayerRequestRequestorList, GET_PrayerRequestRequestorResolvedList, GET_PrayerRequestUserList, PATCH_prayerRequest, POST_prayerRequest, POST_prayerRequestComment, POST_prayerRequestCommentIncrementLikeCount, POST_prayerRequestIncrementPrayerCount, POST_prayerRequestResolved } from './api/prayer-request/prayer-request.mjs';
 
 import { authenticatePartnerMiddleware, authenticateCircleMembershipMiddleware, authenticateClientAccessMiddleware, authenticateCircleLeaderMiddleware, authenticateAdminMiddleware, jwtAuthenticationMiddleware, authenticateLeaderMiddleware, authenticatePrayerRequestRecipientMiddleware, authenticatePrayerRequestRequestorMiddleware, extractCircleMiddleware, extractClientMiddleware } from './api/auth/authorization.mjs';
@@ -191,6 +191,7 @@ apiServer.get('/api/partner/:client/prayer-request-list', GET_PrayerRequestReque
 apiServer.use('/api/user/:client', (request:JwtClientRequest, response:Response, next:NextFunction) => extractClientMiddleware(request, response, next));
 
 apiServer.get('/api/user/:client/public', GET_publicProfile);
+apiServer.get('/api/user/:client/image', GET_profileImage);
 
 
 /**********************************************/
@@ -203,9 +204,13 @@ apiServer.post('/api/user/:client/logout', POST_logout);
 apiServer.get('/api/user/:client', GET_userProfile);
 apiServer.patch('/api/user/:client', PATCH_userProfile);
 apiServer.delete('/api/user/:client', DELETE_userProfile);
+apiServer.delete('/api/user/:client/image', DELETE_profileImage);
 
 apiServer.get('/api/user/:client/prayer-request-list', GET_PrayerRequestRequestorList);
 apiServer.get('/api/user/:client/prayer-request-resolved-list', GET_PrayerRequestRequestorResolvedList);
+
+apiServer.use(bodyParser.raw({type: ['image/png', 'image/jpg', 'image/jpeg'], limit: process.env.IMAGE_UPLOAD_SIZE || '5mb'}));
+apiServer.post('/api/user/:client/image/:file', POST_profileImage);
 
 
 /******************************************************/
@@ -214,6 +219,7 @@ apiServer.get('/api/user/:client/prayer-request-resolved-list', GET_PrayerReques
 apiServer.use('/api/circle/:circle', (request:JwtCircleRequest, response:Response, next:NextFunction) => extractCircleMiddleware(request, response, next));
 
 apiServer.get('/api/circle/:circle/public', GET_publicCircle);
+apiServer.get('/api/circle/:circle/image', GET_circleImage);
 
 apiServer.post('/api/circle/:circle/request', POST_circleMemberRequest);
 apiServer.post('/api/circle/:circle/accept', POST_circleMemberAccept); //Existing Circle Membership Invite must exist (Student Accepts)
@@ -239,6 +245,7 @@ apiServer.use('/api/leader/circle/:circle', (request:JwtCircleRequest, response:
 apiServer.get('/api/leader/circle/:circle', GET_circle);
 apiServer.patch('/api/leader/circle/:circle', PATCH_circle);
 apiServer.delete('/api/leader/circle/:circle', DELETE_circle);
+apiServer.delete('/api/leader/circle/:circle/image', DELETE_circleImage);
 
 apiServer.post('/api/leader/circle/:circle/announcement', POST_circleAnnouncement);
 apiServer.delete('/api/leader/circle/:circle/announcement/:announcement', DELETE_circleAnnouncement);
@@ -247,6 +254,9 @@ apiServer.use('/api/leader/circle/:circle/client/:client', (request:JwtCircleCli
 apiServer.post('/api/leader/circle/:circle/client/:client/invite', POST_circleLeaderMemberInvite);
 apiServer.post('/api/leader/circle/:circle/client/:client/accept', POST_circleLeaderAccept); //Existing Circle Membership Request must exist (Leader Accepts)
 apiServer.delete('/api/leader/circle/:circle/client/:client/leave', DELETE_circleLeaderMember);
+
+apiServer.use(bodyParser.raw({type: ['image/png', 'image/jpg', 'image/jpeg'], limit: process.env.IMAGE_UPLOAD_SIZE || '5mb'}));
+apiServer.post('/api/leader/circle/:circle/image/:file', POST_circleImage);
 
 
 /******************************************************************/

--- a/1-src/services/models/Fields-Sync/inputField.mts
+++ b/1-src/services/models/Fields-Sync/inputField.mts
@@ -5,6 +5,8 @@
 * Sync across all repositories: server, portal, mobile *
 ********************************************************/
 
+export const SUPPORTED_IMAGE_EXTENSION_LIST = ['png', 'jpg', 'jpeg'];  //Sync with AWS settings
+
 export enum InputType {
     TEXT = 'TEXT',
     NUMBER = 'NUMBER',

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "debug": "npm run build & npm run serve"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.417.0",
     "@types/dotenv": "^8.2.0",
     "@types/jsonwebtoken": "^9.0.2",
+    "axios": "^1.5.0",
     "cors": "^2.8.5",
     "dateformat": "^5.0.3",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
**Tested Completly**
1) Tested locally with HTTP key
2) Tested on AWS EC2; added IAM role

**Features**
- User Profile & Circle Profile Image routes: upload/clear/fetch
- Clear Images on profile delete
- Speperate operations of Development and Production
- Uniform file naming based userID or circleID
- Defined supported filetypes in inputField.mts (inherited input config file)
- Admin may edit image URL via filed-configs (upload still must go through:  /api/user/{{user-id}}/image )

**Routes**
Profile Upload: POST /api/user/{{user-id}}/image/image.png
Circle Upload:POST /api/leader/circle/{{circle-id}}/image/image.png
- headers: { Content-Type: image/png }
- Body: raw binary blob

Profile Clear: DELETE /api/user/{{user-id}}/image
Circle Clear:DELETE /api/leader/circle/{{circle-id}}/image

Profile Get: GET /api/user/{{user-id}}/image
Circle Get:GET /api/circle/{{circle-id}}/image