### PR TITLE
57-Circle Relevant Route

### DIFF
--- a/1-src/0-assets/field-sync/api-type-sync/circle-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/circle-types.mts
@@ -56,7 +56,7 @@ export interface CircleResponse {
     announcementList?: CircleAnnouncementListItem[],
     prayerRequestList?: PrayerRequestListItem[],
     requestorID: number,
-    requestorStatus?: CircleStatusEnum
+    requestorStatus: CircleStatusEnum
     image?: string,
 };
 

--- a/1-src/1-api/3-profile/profile.mts
+++ b/1-src/1-api/3-profile/profile.mts
@@ -3,7 +3,7 @@ import URL, { URLSearchParams } from 'url';
 import { ProfileListItem } from '../../0-assets/field-sync/api-type-sync/profile-types.mjs';
 import { EDIT_PROFILE_FIELDS, EDIT_PROFILE_FIELDS_ADMIN, RoleEnum, SIGNUP_PROFILE_FIELDS, SIGNUP_PROFILE_FIELDS_STUDENT, UserSearchFilterEnum } from '../../0-assets/field-sync/input-config-sync/profile-field-config.mjs';
 import USER from '../../2-services/1-models/userModel.mjs';
-import { DATABASE_USER_ROLE_ENUM, USER_TABLE_COLUMNS, USER_TABLE_COLUMNS_REQUIRED } from '../../2-services/2-database/database-types.mjs';
+import { DATABASE_CIRCLE_STATUS_ENUM, DATABASE_USER_ROLE_ENUM, USER_TABLE_COLUMNS, USER_TABLE_COLUMNS_REQUIRED } from '../../2-services/2-database/database-types.mjs';
 import { DB_DELETE_CIRCLE_USER_STATUS, DB_SELECT_MEMBERS_OF_ALL_CIRCLES, DB_SELECT_USER_CIRCLES } from '../../2-services/2-database/queries/circle-queries.mjs';
 import { DB_DELETE_ALL_USER_PRAYER_REQUEST } from '../../2-services/2-database/queries/prayer-request-queries.mjs';
 import { DB_DELETE_USER, DB_DELETE_USER_ROLE, DB_FLUSH_USER_SEARCH_CACHE_ADMIN, DB_INSERT_USER, DB_INSERT_USER_ROLE, DB_SELECT_CONTACTS, DB_SELECT_USER, DB_SELECT_USER_PROFILE, DB_SELECT_USER_ROLES, DB_UNIQUE_USER_EXISTS, DB_UPDATE_USER } from '../../2-services/2-database/queries/user-queries.mjs';
@@ -62,7 +62,7 @@ export const GET_publicProfile =  async (request: JwtClientRequest, response: Re
     const profile:USER = await DB_SELECT_USER(new Map([['userID', request.clientID]]));
 
     if(profile.isValid) {
-        profile.circleList = await DB_SELECT_USER_CIRCLES(profile.userID);   
+        profile.circleList = await DB_SELECT_USER_CIRCLES(profile.userID, DATABASE_CIRCLE_STATUS_ENUM.MEMBER);   
         response.status(200).send(profile.toPublicJSON())   
         log.event('Returning public profile for userID: ', request.clientID);
     } else //Necessary; otherwise no response waits for timeout | Ignored if next() already replied

--- a/1-src/1-api/4-circle/circle.mts
+++ b/1-src/1-api/4-circle/circle.mts
@@ -35,6 +35,7 @@ export const GET_circle =  async(request: JwtCircleRequest, response: Response, 
         circle.requestorStatus = CircleStatusEnum.NON_MEMBER;  //Note: applies to ADMIN too
 
     //Additional Details for all circle statuses
+    circle.memberList = await DB_SELECT_CIRCLE_USER_LIST(circle.circleID, DATABASE_CIRCLE_STATUS_ENUM.MEMBER);
     circle.eventList = getCircleEventSampleList(request.circleID); //TODO Define Circle Event once Implemented
 
     //Public Circle Details only
@@ -47,7 +48,6 @@ export const GET_circle =  async(request: JwtCircleRequest, response: Response, 
     } else if([CircleStatusEnum.MEMBER, CircleStatusEnum.LEADER].includes(circle.requestorStatus) || (request.jwtUserRole === RoleEnum.ADMIN)) { 
         circle.announcementList = await DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT(request.circleID);
         circle.prayerRequestList = await DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST( circle.circleID);
-        circle.memberList = await DB_SELECT_CIRCLE_USER_LIST(circle.circleID, DATABASE_CIRCLE_STATUS_ENUM.MEMBER);
     }
         
     if(circle.requestorStatus === CircleStatusEnum.MEMBER && (request.jwtUserRole !== RoleEnum.ADMIN)) {

--- a/1-src/1-api/4-circle/circle.mts
+++ b/1-src/1-api/4-circle/circle.mts
@@ -22,36 +22,56 @@ import getCircleEventSampleList from './circle-event-samples.mjs';
 /******************
  *  CIRCLE ROUTES
  ******************/
-export const GET_publicCircle =  async(request: JwtCircleRequest, response: Response, next: NextFunction) => {
-    const circle:CIRCLE = await DB_SELECT_CIRCLE_DETAIL({circleID: request.circleID, userID: request.jwtUserID});
-
-    if(circle.isValid) {
-        circle.eventList = getCircleEventSampleList(request.circleID); //TODO Define Circle Event once Implemented
-        response.status(200).send(circle.toPublicJSON());        
-        log.event('Returning public circle for circleID: ', request.circleID);
-    } else //Necessary; otherwise no response waits for timeout | Ignored if next() already replied
-        next(new Exception(404, `GET_publicCircle - circle ${request.circleID} Failed to parse from database and is invalid`));
-};
-
+//Auto determines whether user circle status; returning only relevant details
 export const GET_circle =  async(request: JwtCircleRequest, response: Response, next: NextFunction) => {
     const circle:CIRCLE = await DB_SELECT_CIRCLE_DETAIL({circleID: request.circleID, userID: request.jwtUserID});
-    circle.announcementList = await DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT(request.circleID);
-    circle.eventList = getCircleEventSampleList(request.circleID); //TODO Define Circle Event once Implemented
-    circle.prayerRequestList = await DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST( circle.circleID);
-    circle.memberList = await DB_SELECT_CIRCLE_USER_LIST(circle.circleID, DATABASE_CIRCLE_STATUS_ENUM.MEMBER);
 
-    if(request.jwtUserID === circle.leaderID || request.jwtUserRole === RoleEnum.ADMIN) {
+    if(!circle.isValid) { //Necessary; otherwise no response waits for timeout | Ignored if next() already replied
+        next(new Exception(404, `GET_circle - circle ${request.circleID} Failed to parse from database and is invalid`));
+        return;
+    } 
+
+    if(circle.requestorStatus === undefined)
+        circle.requestorStatus = CircleStatusEnum.NON_MEMBER;  //Note: applies to ADMIN too
+
+    //Additional Details for all circle statuses
+    circle.eventList = getCircleEventSampleList(request.circleID); //TODO Define Circle Event once Implemented
+
+    //Public Circle Details only
+    if([CircleStatusEnum.NON_MEMBER, CircleStatusEnum.INVITE, CircleStatusEnum.REQUEST].includes(circle.requestorStatus) && (request.jwtUserRole !== RoleEnum.ADMIN)) { 
+        response.status(200).send(circle.toPublicJSON());        
+        log.event('Returning circle public details for circleID: ', request.circleID);
+        return;
+
+    //Additional MEMBER Detail Queries
+    } else if([CircleStatusEnum.MEMBER, CircleStatusEnum.LEADER].includes(circle.requestorStatus) || (request.jwtUserRole === RoleEnum.ADMIN)) { 
+        circle.announcementList = await DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT(request.circleID);
+        circle.prayerRequestList = await DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST( circle.circleID);
+        circle.memberList = await DB_SELECT_CIRCLE_USER_LIST(circle.circleID, DATABASE_CIRCLE_STATUS_ENUM.MEMBER);
+    }
+        
+    if(circle.requestorStatus === CircleStatusEnum.MEMBER && (request.jwtUserRole !== RoleEnum.ADMIN)) {
+        response.status(200).send(circle.toMemberJSON());        
+        log.event('Returning circle member details for circleID: ', request.circleID);
+        return;
+    }
+
+    //Additional LEADER Detail Queries
+    else if((request.jwtUserID === circle.leaderID ) || (request.jwtUserRole === RoleEnum.ADMIN)) {
         circle.pendingInviteList = await DB_SELECT_CIRCLE_USER_LIST(circle.circleID, DATABASE_CIRCLE_STATUS_ENUM.INVITE);
         circle.pendingRequestList = await DB_SELECT_CIRCLE_USER_LIST(circle.circleID, DATABASE_CIRCLE_STATUS_ENUM.REQUEST);
     }
+
     if(request.jwtUserRole === RoleEnum.ADMIN)
         response.status(200).send(circle.toJSON()); 
+
     else if(request.jwtUserID === circle.leaderID)
-        response.status(200).send(circle.toLeaderJSON()); 
-    else
-        response.status(200).send(circle.toMemberJSON());        
-    log.event('Returning circle for circleID: ', request.circleID);
+        response.status(200).send(circle.toLeaderJSON());
+
+    else //Never should reach
+        next(new Exception(500, `GET_circle - circle ${request.circleID} Failed to identify requestor: ${circle.requestorID} with circle requestorStatus: ${circle.requestorStatus}`));
 };
+
 
 //List of all circles user is member, invited, requested (not sorted)
 export const GET_userCircleList = async(request: JwtRequest, response: Response, next: NextFunction) => {

--- a/1-src/2-services/1-models/circleModel.mts
+++ b/1-src/2-services/1-models/circleModel.mts
@@ -19,8 +19,8 @@ export default class CIRCLE implements BASE_MODEL  {
     isValid: boolean = false;
 
     //Private static list of class property fields | (This is display-responses; NOT edit-access.)
-    #publicPropertyList = ['circleID', 'leaderID', 'name', 'description', 'postalCode', 'image', 'requestorID', 'requestorStatus', 'leaderProfile', 'eventList'];
-    #memberPropertyList = [...this.#publicPropertyList, 'announcementList', 'prayerRequestList', 'memberList', 'pendingRequestList', 'pendingInviteList'];
+    #publicPropertyList = ['circleID', 'leaderID', 'name', 'description', 'postalCode', 'image', 'requestorID', 'requestorStatus', 'leaderProfile', 'memberList', 'eventList'];
+    #memberPropertyList = [...this.#publicPropertyList, 'announcementList', 'prayerRequestList', 'pendingRequestList', 'pendingInviteList'];
     #leaderPropertyList = [...this.#memberPropertyList, 'inviteToken'];
     #propertyList = [...this.#leaderPropertyList, 'notes'];
 

--- a/1-src/2-services/1-models/userModel.mts
+++ b/1-src/2-services/1-models/userModel.mts
@@ -41,7 +41,7 @@ export default class USER implements BASE_MODEL {
 
   //Query separate Tables
   userRoleList: RoleEnum[] = [RoleEnum.STUDENT];
-  circleList: CircleListItem[] = [];
+  circleList: CircleListItem[] = [];               //Includes all status: MEMBER|INVITE|REQUEST|LEADER
   partnerList: ProfileListItem[] = [];
   prayerRequestList: PrayerRequestListItem[] = [];
   contactList: ProfileListItem[] = [];

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -22,7 +22,7 @@ import { authenticatePartnerMiddleware, authenticateCircleMembershipMiddleware, 
 import { GET_userContacts } from './1-api/7-chat/chat.mjs';
 import { GET_allUserCredentials, GET_jwtVerify, POST_login, POST_logout, POST_authorization_reset } from './1-api/2-auth/auth.mjs';
 import { GET_EditProfileFields, GET_partnerProfile, GET_profileAccessUserList, GET_publicProfile, GET_RoleList, GET_SignupProfileFields, GET_userProfile, PATCH_userProfile, GET_AvailableAccount, DELETE_userProfile, POST_profileImage, DELETE_profileImage, GET_profileImage, GET_SearchUserList, DELETE_flushClientSearchCache, POST_signup } from './1-api/3-profile/profile.mjs';
-import { GET_publicCircle, GET_circle, POST_newCircle, DELETE_circle, DELETE_circleLeaderMember, DELETE_circleMember, PATCH_circle, POST_circleLeaderAccept, POST_circleMemberAccept, POST_circleMemberJoinAdmin, POST_circleMemberRequest, POST_circleLeaderMemberInvite, DELETE_circleAnnouncement, POST_circleAnnouncement, POST_circleImage, DELETE_circleImage, GET_circleImage, GET_SearchCircleList, DELETE_flushCircleSearchCache } from './1-api/4-circle/circle.mjs';
+import { GET_circle, POST_newCircle, DELETE_circle, DELETE_circleLeaderMember, DELETE_circleMember, PATCH_circle, POST_circleLeaderAccept, POST_circleMemberAccept, POST_circleMemberJoinAdmin, POST_circleMemberRequest, POST_circleLeaderMemberInvite, DELETE_circleAnnouncement, POST_circleAnnouncement, POST_circleImage, DELETE_circleImage, GET_circleImage, GET_SearchCircleList, DELETE_flushCircleSearchCache } from './1-api/4-circle/circle.mjs';
 import { DELETE_prayerRequest, DELETE_prayerRequestComment, GET_PrayerRequest, GET_PrayerRequestRequestorDetails, GET_PrayerRequestCircleList, GET_PrayerRequestRequestorList, GET_PrayerRequestRequestorResolvedList, GET_PrayerRequestUserList, PATCH_prayerRequest, POST_prayerRequest, POST_prayerRequestComment, POST_prayerRequestCommentIncrementLikeCount, POST_prayerRequestIncrementPrayerCount, POST_prayerRequestResolved } from './1-api/5-prayer-request/prayer-request.mjs';
 
 //Import Services
@@ -219,7 +219,7 @@ apiServer.post('/api/user/:client/image/:file', POST_profileImage);
 /******************************************************/
 apiServer.use('/api/circle/:circle', (request:JwtCircleRequest, response:Response, next:NextFunction) => extractCircleMiddleware(request, response, next));
 
-apiServer.get('/api/circle/:circle/public', GET_publicCircle);
+apiServer.get('/api/circle/:circle', GET_circle);  //Handles relevant circle status
 apiServer.get('/api/circle/:circle/image', GET_circleImage);
 
 apiServer.post('/api/circle/:circle/request', POST_circleMemberRequest);
@@ -231,8 +231,6 @@ apiServer.delete('/api/circle/:circle/leave', DELETE_circleMember);
 /* Authenticate Circle Membership */
 /**********************************/
 apiServer.use('/api/circle/:circle', (request:JwtCircleRequest, response:Response, next:NextFunction) => authenticateCircleMembershipMiddleware(request, response, next));
-
-apiServer.get('/api/circle/:circle', GET_circle);
 
 apiServer.get('/api/circle/:circle/prayer-request-list', GET_PrayerRequestCircleList);
 
@@ -310,8 +308,8 @@ apiServer.use((error: Exception, request: Request, response:Response, next: Next
         action: action,
         type: request.method,
         url: request.originalUrl,
-        params: request.params?.toString(),
-        query: request.query?.toString(),
+        params: JSON.stringify(request.params),
+        query: JSON.stringify(request.query),
         header: request.headers,
         body: request.body
     }


### PR DESCRIPTION
Single route that auto determines whether user circle status; returning only relevant details.

Get Circle Details: `GET /api/circle/#`
Supporting:
- Non Member / Public Response
- Member  Response
- Leader Response
- ADMIN Response

Deprecated Route: `GET /api/circle/#/public`

Also `CircleResponse.requestorStatus` is now guaranteed:
`circle-types.tsx`: `requestorStatus?: CircleStatusEnum` -> `requestorStatus: CircleStatusEnum` 

Note: LoginResponse -> `ProfileResponse.circleList` includes all three statuses: MEMBER | INVITE | REQUEST
![image](https://github.com/PEW35MINISTRY/server/assets/53985473/bd6c4f1e-0af8-4b68-a4f6-8c40d2edf8c9)