### PR TITLE
[68] Add Static constructors and create static propertyLists for mode…

### DIFF
--- a/1-src/1-api/3-profile/profile.mts
+++ b/1-src/1-api/3-profile/profile.mts
@@ -113,7 +113,7 @@ export const GET_partnerProfile = async (request: JwtClientRequest, response: Re
         else if(await validateNewRoleTokenList({newRoleList:newProfile.userRoleList, jsonRoleTokenList: request.body.userRoleTokenList, email: newProfile.email}) === false)
             next(new Exception(401, `Signup Failed :: failed to verify token for user roles: ${JSON.stringify(newProfile.userRoleList)}for new user ${newProfile.email}.`, 'Ineligible Account Type'));
 
-        else if(await DB_INSERT_USER(newProfile.getValidProperties(USER_TABLE_COLUMNS, false)) === false) 
+        else if(await DB_INSERT_USER(newProfile.getDatabaseProperties()) === false) 
                 next(new Exception(500, `Signup Failed :: Failed to save new user account.`, 'Save Failed'));
 
         //New Account Success -> Auto Login Response
@@ -149,8 +149,8 @@ export const PATCH_userProfile = async (request: ProfileEditRequest, response: R
         if(await validateNewRoleTokenList({newRoleList:editProfile.userRoleList, jsonRoleTokenList: request.body.userRoleTokenList, email: editProfile.email, currentRoleList: currentRoleList, adminOverride: (request.jwtUserRole === RoleEnum.ADMIN)}) === false)
             next(new Exception(401, `Edit Profile Failed :: failed to verify token for user roles: ${JSON.stringify(editProfile.userRoleList)} for user ${editProfile.email}.`, 'Ineligible Account Type'));
 
-        else if((editProfile.getUniqueDatabaseProperties(currentProfile).size > 0 )
-                && await DB_UPDATE_USER(request.clientID, editProfile.getUniqueDatabaseProperties(currentProfile)) === false) 
+        else if((USER.getUniqueDatabaseProperties(editProfile, currentProfile).size > 0 )
+                && await DB_UPDATE_USER(request.clientID, USER.getUniqueDatabaseProperties(editProfile, currentProfile)) === false) 
             next(new Exception(500, `Edit Profile Failed :: Failed to update user ${request.clientID} account.`, 'Save Failed'));
 
         else {

--- a/1-src/1-api/5-prayer-request/prayer-request.mts
+++ b/1-src/1-api/5-prayer-request/prayer-request.mts
@@ -79,7 +79,7 @@ export const POST_prayerRequest = async (request: PrayerRequestPostRequest, resp
             next(new Exception(400, `Create Prayer Request Failed :: Missing Required Fields: ${JSON.stringify(PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED)}.`, 'Missing Details'));
 
         else { 
-                const savedPrayerRequest:PRAYER_REQUEST = await DB_INSERT_AND_SELECT_PRAYER_REQUEST(newPrayerRequest.getDatabaseProperties());
+                const savedPrayerRequest:PRAYER_REQUEST = await DB_INSERT_AND_SELECT_PRAYER_REQUEST(newPrayerRequest.getDatabaseIdentifyingProperties());
 
                 if(!savedPrayerRequest.isValid) 
                     next(new Exception(500, 'Create Prayer Request Failed :: Failed to save new prayer request to database.', 'Save Failed'));
@@ -106,8 +106,8 @@ export const PATCH_prayerRequest = async (request: PrayerRequestPatchRequest, re
 
     if(currentPrayerRequest.isValid && editPrayerRequest !== undefined && editPrayerRequest.isValid) {  //undefined handles next(Exception)
         
-        if((editPrayerRequest.getUniqueDatabaseProperties(currentPrayerRequest).size > 0 )
-                && await DB_UPDATE_PRAYER_REQUEST(request.prayerRequestID, editPrayerRequest.getUniqueDatabaseProperties(currentPrayerRequest)) === false) 
+        if((PRAYER_REQUEST.getUniqueDatabaseProperties(editPrayerRequest, currentPrayerRequest).size > 0 )
+                && await DB_UPDATE_PRAYER_REQUEST(request.prayerRequestID, PRAYER_REQUEST.getUniqueDatabaseProperties(editPrayerRequest, currentPrayerRequest)) === false) 
             next(new Exception(500, `Edit Prayer Request Failed :: Failed to update prayer request ${request.prayerRequestID}.`, 'Save Failed'));
 
         else { //Handle changes in user recipient lists

--- a/1-src/2-services/1-models/baseModel.mts
+++ b/1-src/2-services/1-models/baseModel.mts
@@ -20,9 +20,9 @@ export default interface BASE_MODEL {
 
   getValidProperties: (properties:string[], includeID:boolean) => Map<string, any>;
 
-  getUniqueDatabaseProperties: (model:any) => Map<string, any>;
+  getDatabaseProperties: () => Map<string, any>;
 
-  getDatabaseProperties: (model:any) => Map<string, any>;
+  getDatabaseIdentifyingProperties: (model:any) => Map<string, any>;
 
   toListItem: () => {};
 

--- a/1-src/2-services/1-models/circleAnnouncementModel.mts
+++ b/1-src/2-services/1-models/circleAnnouncementModel.mts
@@ -72,9 +72,9 @@ export default class CIRCLE_ANNOUNCEMENT implements BASE_MODEL  {
         return map;
     }
   
-    getDatabaseProperties = (): Map<string, any> => this.getValidProperties(CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS, false);
+    getDatabaseProperties = ():Map<string, any> => this.getValidProperties(CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS, false);
 
-    getDatabaseIdentifyingProperties = (): Map<string, any> => this.getValidProperties(CIRCLE_ANNOUNCEMENT.#databaseIdentifyingPropertyList, false);
+    getDatabaseIdentifyingProperties = ():Map<string, any> => this.getValidProperties(CIRCLE_ANNOUNCEMENT.#databaseIdentifyingPropertyList, false);
 
     toJSON = ():DATABASE_CIRCLE_ANNOUNCEMENT => Object.fromEntries(this.getValidProperties()) as unknown as DATABASE_CIRCLE_ANNOUNCEMENT;
 

--- a/1-src/2-services/1-models/circleModel.mts
+++ b/1-src/2-services/1-models/circleModel.mts
@@ -129,9 +129,9 @@ export default class CIRCLE implements BASE_MODEL  {
         return map;
       }
 
-    getDatabaseProperties = (): Map<string, any> => this.getValidProperties(CIRCLE_TABLE_COLUMNS, false);
+    getDatabaseProperties = ():Map<string, any> => this.getValidProperties(CIRCLE_TABLE_COLUMNS, false);
 
-    getDatabaseIdentifyingProperties = (): Map<string, any> => this.getValidProperties(CIRCLE.#databaseIdentifyingPropertyList, false);
+    getDatabaseIdentifyingProperties = ():Map<string, any> => this.getValidProperties(CIRCLE.#databaseIdentifyingPropertyList, false);
 
     toJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(CIRCLE.#propertyList)) as unknown as DATABASE_CIRCLE;
 

--- a/1-src/2-services/1-models/circleModel.mts
+++ b/1-src/2-services/1-models/circleModel.mts
@@ -19,10 +19,11 @@ export default class CIRCLE implements BASE_MODEL  {
     isValid: boolean = false;
 
     //Private static list of class property fields | (This is display-responses; NOT edit-access.)
-    #publicPropertyList = ['circleID', 'leaderID', 'name', 'description', 'postalCode', 'image', 'requestorID', 'requestorStatus', 'leaderProfile', 'memberList', 'eventList'];
-    #memberPropertyList = [...this.#publicPropertyList, 'announcementList', 'prayerRequestList', 'pendingRequestList', 'pendingInviteList'];
-    #leaderPropertyList = [...this.#memberPropertyList, 'inviteToken'];
-    #propertyList = [...this.#leaderPropertyList, 'notes'];
+    static #databaseIdentifyingPropertyList = ['leaderID', 'name', 'description', 'inviteToken']; //exclude: circleID, complex types, and lists
+    static #publicPropertyList = ['circleID', 'leaderID', 'name', 'description', 'postalCode', 'image', 'requestorID', 'requestorStatus', 'leaderProfile', 'memberList', 'eventList'];
+    static #memberPropertyList = [...CIRCLE.#publicPropertyList, 'announcementList', 'prayerRequestList', 'pendingRequestList', 'pendingInviteList'];
+    static #leaderPropertyList = [...CIRCLE.#memberPropertyList, 'inviteToken'];
+    static #propertyList = [...CIRCLE.#leaderPropertyList, 'notes'];
 
     circleID: number = -1;
     leaderID: number;
@@ -45,31 +46,64 @@ export default class CIRCLE implements BASE_MODEL  {
     pendingRequestList: ProfileListItem[] = [];
     pendingInviteList: ProfileListItem[] = [];
 
-    constructor(DB?:DATABASE_CIRCLE, circleID?:number) {
+    //Used as error case or blank
+    constructor(id:number = -1) {
+        this.circleID = id;
+        this.isValid = false;
+      }
+
+    static constructByDatabase = (DB:DATABASE_CIRCLE):CIRCLE => {
         try {
-            this.circleID = circleID || DB?.circleID || -1;
+            const newCircle:CIRCLE = new CIRCLE(DB.circleID || -1);
 
-            if(DB !== undefined) {
-                this.leaderID = DB.leaderID;
-                this.name = DB.name;
-                this.description = DB.description;
-                this.postalCode = DB.postalCode;
-                this.isActive = DB.isActive ? true : false;
-                this.inviteToken = DB.inviteToken;
-                this.image = DB.image;
-                this.notes = DB.notes;
+            newCircle.leaderID = DB.leaderID;
+            newCircle.name = DB.name;
+            newCircle.description = DB.description;
+            newCircle.postalCode = DB.postalCode;
+            newCircle.isActive = DB.isActive ? true : false;
+            newCircle.inviteToken = DB.inviteToken;
+            newCircle.image = DB.image;
+            newCircle.notes = DB.notes;
+            newCircle.isValid = true;
 
-                this.isValid = true;
-            }
+            return newCircle;
+
         } catch(error) {
             log.db('INVALID Database Object; failed to parse CIRCLE', JSON.stringify(DB), error);
+            return new CIRCLE();
+        }
+    }
+
+    //Clone database model values only (not copying references for ListItems)
+    static constructByClone = (circle:CIRCLE):CIRCLE => {
+        try { //MUST copy primitives properties directly and create new complex types to avoid reference linking
+            const newCircle:CIRCLE = new CIRCLE(circle.circleID); 
+
+            if(newCircle.circleID > 0) {
+                newCircle.leaderID = circle.leaderID;
+                newCircle.name = circle.name;
+                newCircle.description = circle.description;
+                newCircle.postalCode = circle.postalCode;
+                newCircle.isActive = circle.isActive;
+                newCircle.inviteToken = circle.inviteToken;
+                newCircle.image = circle.image;
+                newCircle.notes = circle.notes;
+                newCircle.isValid = true;
+            }
+
+            return newCircle;
+
+        } catch(error) {
+            log.error('INVALID Object; failed to clone CIRCLE', JSON.stringify(circle), error);
+            return new CIRCLE();
         }
     }
 
     /* PROPERTY FIELD UTILITIES */
-    hasProperty = (field:string) => this.#propertyList.includes(field);
+    static hasProperty = (field: string) => CIRCLE.#propertyList.includes(field);
+    hasProperty = (field:string) => CIRCLE.#propertyList.includes(field); //Defined in BASE_MODEL; used for JSON parsing
 
-    getValidProperties = (properties:string[] = this.#propertyList, includeCircleID:boolean = true):Map<string, any> => {
+    getValidProperties = (properties:string[] = CIRCLE.#propertyList, includeCircleID:boolean = true):Map<string, any> => {
         const map = new Map<string, any>();
         properties.filter((p) => (includeCircleID || (p !== 'circleID'))).forEach((field) => {
             if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
@@ -95,15 +129,17 @@ export default class CIRCLE implements BASE_MODEL  {
         return map;
       }
 
-    getDatabaseProperties = ():Map<string, any> => this.getUniqueDatabaseProperties(new CIRCLE());
+    getDatabaseProperties = (): Map<string, any> => this.getValidProperties(CIRCLE_TABLE_COLUMNS, false);
 
-    toJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(this.#propertyList)) as unknown as DATABASE_CIRCLE;
+    getDatabaseIdentifyingProperties = (): Map<string, any> => this.getValidProperties(CIRCLE.#databaseIdentifyingPropertyList, false);
 
-    toPublicJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(this.#publicPropertyList)) as unknown as DATABASE_CIRCLE;
+    toJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(CIRCLE.#propertyList)) as unknown as DATABASE_CIRCLE;
 
-    toMemberJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(this.#memberPropertyList)) as unknown as DATABASE_CIRCLE;
+    toPublicJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(CIRCLE.#publicPropertyList)) as unknown as DATABASE_CIRCLE;
 
-    toLeaderJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(this.#leaderPropertyList)) as unknown as DATABASE_CIRCLE;
+    toMemberJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(CIRCLE.#memberPropertyList)) as unknown as DATABASE_CIRCLE;
+
+    toLeaderJSON = ():DATABASE_CIRCLE => Object.fromEntries(this.getValidProperties(CIRCLE.#leaderPropertyList)) as unknown as DATABASE_CIRCLE;
 
     toListItem = ():CircleListItem => ({circleID: this.circleID, name: this.name, image: this.image});
 

--- a/1-src/2-services/1-models/prayerRequestModel.mts
+++ b/1-src/2-services/1-models/prayerRequestModel.mts
@@ -19,8 +19,9 @@ export default class PRAYER_REQUEST implements BASE_MODEL  {
     isValid: boolean = false;
 
     //Private static list of class property fields | (This is display-responses; NOT edit-access.)
-    #displayPropertyList = [ 'prayerRequestID', 'requestorID', 'topic', 'description', 'prayerCount', 'isOnGoing', 'isResolved', 'tagList', 'expirationDate', 'requestorProfile', 'commentList', 'userRecipientList', 'circleRecipientList' ];
-    #propertyList = [ ...this.#displayPropertyList, 'addUserRecipientIDList', 'removeUserRecipientIDList', 'addCircleRecipientIDList', 'removeCircleRecipientIDList' ];
+    static #databaseIdentifyingPropertyList = ['requestorID', 'topic', 'description']; //exclude: prayerRequestID, complex types, and lists
+    static #displayPropertyList = [ 'prayerRequestID', 'requestorID', 'topic', 'description', 'prayerCount', 'isOnGoing', 'isResolved', 'tagList', 'expirationDate', 'requestorProfile', 'commentList', 'userRecipientList', 'circleRecipientList' ];
+    static #propertyList = [ ...PRAYER_REQUEST.#displayPropertyList, 'addUserRecipientIDList', 'removeUserRecipientIDList', 'addCircleRecipientIDList', 'removeCircleRecipientIDList' ];
 
     prayerRequestID: number = -1;
     requestorID: number;
@@ -44,32 +45,81 @@ export default class PRAYER_REQUEST implements BASE_MODEL  {
     addCircleRecipientIDList: number[];
     removeCircleRecipientIDList: number[];
 
-    constructor(DB?:DATABASE_PRAYER_REQUEST, prayerRequestID?:number) {
+    //Used as error case or blank
+    constructor(id:number = -1) {
+        this.prayerRequestID = id;
+        this.isValid = false;
+      }
+
+    static constructByDatabase = (DB:DATABASE_PRAYER_REQUEST):PRAYER_REQUEST => {
         try {
-            this.prayerRequestID = prayerRequestID || DB?.prayerRequestID || -1;
+            const newPrayerRequest:PRAYER_REQUEST = new PRAYER_REQUEST(DB.prayerRequestID || -1);
 
-            if(DB !== undefined) {
-                this.requestorID = DB.requestorID;
-                this.topic = DB.topic;
-                this.description = DB.description;
-                this.prayerCount = DB.prayerCount;
-                this.isOnGoing = DB.isOnGoing ? true : false;
-                this.isResolved = DB.isResolved ? true : false;
-                this.expirationDate = DB.expirationDate;
+            newPrayerRequest.requestorID = DB.requestorID;
+            newPrayerRequest.topic = DB.topic;
+            newPrayerRequest.description = DB.description;
+            newPrayerRequest.prayerCount = DB.prayerCount;
+            newPrayerRequest.isOnGoing = DB.isOnGoing ? true : false;
+            newPrayerRequest.isResolved = DB.isResolved ? true : false;
+            newPrayerRequest.expirationDate = DB.expirationDate;
+            newPrayerRequest.tagList = PRAYER_REQUEST.prayerRequestParseTags(DB.tagsStringified);
+            newPrayerRequest.isValid = true;
 
-                this.tagList = prayerRequestParseTags(DB.tagsStringified);
-                
-                this.isValid = true;
-            }
+            return newPrayerRequest;
+
         } catch(error) {
             log.db('INVALID Database Object; failed to parse PRAYER_REQUEST', JSON.stringify(DB), error);
+            return new PRAYER_REQUEST();
         }
     }
 
-    /* PROPERTY FIELD UTILITIES */
-    hasProperty = (field:string) => this.#propertyList.includes(field);
+      //Clone database model values only (not copying references for ListItems)
+    static constructByClone = (prayerRequest:PRAYER_REQUEST):PRAYER_REQUEST => {
+        try { //MUST copy primitives properties directly and create new complex types to avoid reference linking
+            const newPrayerRequest:PRAYER_REQUEST = new PRAYER_REQUEST(prayerRequest.prayerRequestID); 
 
-    getValidProperties = (properties:string[] = this.#displayPropertyList, includePrayerRequestID:boolean = true):Map<string, any> => {
+            if(newPrayerRequest.prayerRequestID > 0) {
+                newPrayerRequest.requestorID = prayerRequest.requestorID;
+                newPrayerRequest.topic = prayerRequest.topic;
+                newPrayerRequest.description = prayerRequest.description;
+                newPrayerRequest.prayerCount = prayerRequest.prayerCount;
+                newPrayerRequest.isOnGoing = prayerRequest.isOnGoing;
+                newPrayerRequest.isResolved = prayerRequest.isResolved;
+                newPrayerRequest.expirationDate = new Date(prayerRequest.expirationDate?.getTime());
+                newPrayerRequest.tagList = PRAYER_REQUEST.prayerRequestParseTags(JSON.stringify(prayerRequest.tagList));
+                newPrayerRequest.isValid = true;
+            }
+
+            return newPrayerRequest;
+
+        } catch(error) {
+            log.error('INVALID Object; failed to clone PRAYER_REQUEST', JSON.stringify(prayerRequest), error);
+            return new PRAYER_REQUEST();
+        }
+    }
+
+    /* ADDITIONAL UTILITIES */
+    static prayerRequestParseTags = (tagsStringified:string):PrayerRequestTagEnum[] => {
+        const tagList = [];
+        if(tagsStringified !== undefined && tagsStringified !== null && tagsStringified.length > 0) {        
+            try {
+                const list:string[] = JSON.parse(tagsStringified);
+                list.forEach((item:string) => {
+                    if(Object.values(PrayerRequestTagEnum).includes(PrayerRequestTagEnum[item])) 
+                        tagList.push(PrayerRequestTagEnum[item]);
+                });
+            } catch(error) {
+                log.error('Failed to parse prayer request tags', tagsStringified, error);
+            }
+        }
+        return tagList;
+    }
+
+    /* PROPERTY FIELD UTILITIES */
+    static hasProperty = (field: string) => PRAYER_REQUEST.#propertyList.includes(field);
+    hasProperty = (field:string) => PRAYER_REQUEST.#propertyList.includes(field); //Defined in BASE_MODEL; used for JSON parsing
+
+    getValidProperties = (properties:string[] = PRAYER_REQUEST.#displayPropertyList, includePrayerRequestID:boolean = true):Map<string, any> => {
         const map = new Map<string, any>();
         properties.filter((p) => (includePrayerRequestID || (p !== 'prayerRequestID'))).forEach((field) => {
             if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
@@ -84,23 +134,29 @@ export default class PRAYER_REQUEST implements BASE_MODEL  {
     }
 
  
-    getUniqueDatabaseProperties = (prayerRequest:PRAYER_REQUEST):Map<string, any> => {
+    static getUniqueDatabaseProperties = (editPrayerRequest:PRAYER_REQUEST, currentPrayerRequest:PRAYER_REQUEST):Map<string, any> => {
         const map = new Map<string, any>();
         PRAYER_REQUEST_TABLE_COLUMNS.filter((c) => ((c !== 'prayerRequestID'))).forEach((field) => {
 
-            if(field === 'tagsStringified' && (JSON.stringify(Array.from(this['tagList']).sort()) !== JSON.stringify(Array.from(prayerRequest['tagList']).sort())))
-                map.set('tagsStringified', JSON.stringify(this['tagList']));
+            if(field === 'tagsStringified' && (JSON.stringify(Array.from(editPrayerRequest.tagList).sort()) !== JSON.stringify(Array.from(currentPrayerRequest.tagList).sort())))
+                map.set('tagsStringified', JSON.stringify(editPrayerRequest.tagList));
             
-            else if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
-                && ((Array.isArray(this[field]) 
-                    && (JSON.stringify(Array.from(this[field]).sort()) !== JSON.stringify(Array.from(prayerRequest[field]).sort()))) 
-                || (this[field] !== prayerRequest[field])))
-                    map.set(field, this[field]);
+            else if (field === 'expirationDate') { //Must compare dates as numbers
+                    if (editPrayerRequest.expirationDate.getTime() !== currentPrayerRequest.expirationDate.getTime())
+                      map.set(field, editPrayerRequest[field]);
+               
+            } else if(editPrayerRequest.hasOwnProperty(field) && editPrayerRequest[field] !== undefined && editPrayerRequest[field] !== null
+                && ((Array.isArray(editPrayerRequest[field]) 
+                    && (JSON.stringify(Array.from(editPrayerRequest[field]).sort()) !== JSON.stringify(Array.from(currentPrayerRequest[field]).sort()))) 
+                || (editPrayerRequest[field] !== currentPrayerRequest[field])))
+                    map.set(field, editPrayerRequest[field]);
         });
         return map;
       }
 
-    getDatabaseProperties = ():Map<string, any> => this.getUniqueDatabaseProperties(new PRAYER_REQUEST());
+    getDatabaseProperties = (): Map<string, any> => this.getValidProperties(PRAYER_REQUEST_TABLE_COLUMNS, false);
+
+    getDatabaseIdentifyingProperties = (): Map<string, any> => this.getValidProperties(PRAYER_REQUEST.#databaseIdentifyingPropertyList, false);
 
     toJSON = ():DATABASE_PRAYER_REQUEST => Object.fromEntries(this.getValidProperties()) as unknown as DATABASE_PRAYER_REQUEST;
 
@@ -127,20 +183,3 @@ export default class PRAYER_REQUEST implements BASE_MODEL  {
         return undefined;
     }
 };
-
-/* ADDITIONAL UTILITIES */
-export const prayerRequestParseTags = (tagsStringified:string):PrayerRequestTagEnum[] => {
-    const tagList = [];
-    if(tagsStringified !== undefined && tagsStringified !== null && tagsStringified.length > 0) {        
-        try {
-            const list:string[] = JSON.parse(tagsStringified);
-            list.forEach((item:string) => {
-                if(Object.values(PrayerRequestTagEnum).includes(PrayerRequestTagEnum[item])) 
-                    tagList.push(PrayerRequestTagEnum[item]);
-            });
-        } catch(error) {
-            log.error('Failed to parse prayer request tags', tagsStringified, error);
-        }
-    }
-    return tagList;
-}

--- a/1-src/2-services/1-models/prayerRequestModel.mts
+++ b/1-src/2-services/1-models/prayerRequestModel.mts
@@ -154,9 +154,9 @@ export default class PRAYER_REQUEST implements BASE_MODEL  {
         return map;
       }
 
-    getDatabaseProperties = (): Map<string, any> => this.getValidProperties(PRAYER_REQUEST_TABLE_COLUMNS, false);
+    getDatabaseProperties = ():Map<string, any> => this.getValidProperties(PRAYER_REQUEST_TABLE_COLUMNS, false);
 
-    getDatabaseIdentifyingProperties = (): Map<string, any> => this.getValidProperties(PRAYER_REQUEST.#databaseIdentifyingPropertyList, false);
+    getDatabaseIdentifyingProperties = ():Map<string, any> => this.getValidProperties(PRAYER_REQUEST.#databaseIdentifyingPropertyList, false);
 
     toJSON = ():DATABASE_PRAYER_REQUEST => Object.fromEntries(this.getValidProperties()) as unknown as DATABASE_PRAYER_REQUEST;
 

--- a/1-src/2-services/1-models/userModel.mts
+++ b/1-src/2-services/1-models/userModel.mts
@@ -20,10 +20,11 @@ export default class USER implements BASE_MODEL {
   isValid: boolean = false;
 
   //Private static list of class property fields | (This is display-responses; NOT edit-access -> see: profile-field-config.mts)
-  #publicPropertyList = ['userID', 'firstName', 'lastName', 'displayName', 'postalCode', 'dateOfBirth', 'gender', 'image', 'circleList', 'userRole'];
-  #partnerPropertyList = [...this.#publicPropertyList, 'walkLevel'];
-  #userPropertyList = [...this.#partnerPropertyList, 'email', 'isActive', 'notes', 'userRoleList', 'partnerList', 'prayerRequestList', 'contactList', 'profileAccessList'];
-  #propertyList = this.#userPropertyList.filter(property => !['circleList', 'partnerList', 'prayerRequestList', 'contactList'].includes(property)); //Not Edited through Model
+  static #databaseIdentifyingPropertyList = ['firstName', 'lastName', 'displayName', 'email']; //exclude: usedID, complex types, and lists
+  static #publicPropertyList = ['userID', 'firstName', 'lastName', 'displayName', 'postalCode', 'dateOfBirth', 'gender', 'image', 'circleList', 'userRole'];
+  static #partnerPropertyList = [...USER.#publicPropertyList, 'walkLevel'];
+  static #userPropertyList = [...USER.#partnerPropertyList, 'email', 'isActive', 'notes', 'userRoleList', 'partnerList', 'prayerRequestList', 'contactList', 'profileAccessList'];
+  static #propertyList = USER.#userPropertyList.filter(property => !['circleList', 'partnerList', 'prayerRequestList', 'contactList'].includes(property)); //Not Edited through Model
 
   userID: number = -1;
   firstName?: string;
@@ -47,92 +48,135 @@ export default class USER implements BASE_MODEL {
   contactList: ProfileListItem[] = [];
   profileAccessList: ProfileListItem[] = []; //Leaders
 
-
-  constructor(DB?:DATABASE_USER, userID?:number) {
-        try {
-            this.userID = userID || DB?.userID || -1;
-
-            if(DB !== undefined) {
-                this.firstName = DB.firstName;
-                this.lastName = DB.lastName;
-                this.displayName = DB.displayName;
-                this.email = DB.email;
-                this.passwordHash = DB.passwordHash;
-                this.postalCode = DB.postalCode;
-                this.dateOfBirth = DB.dateOfBirth;  //Date converted by MYSQL2
-                this.gender = GenderEnum[DB.gender];
-                this.isActive = DB.isActive ? true : false;
-                this.walkLevel = DB.walkLevel as number;
-                this.image = DB.image;
-                this.notes = DB.notes;
-                this.userRoleList = [RoleEnum[DB.userRole] || RoleEnum.STUDENT];
-
-                this.isValid = true;
-            }
-        } catch(error) {
-            log.db('INVALID Database Object; failed to parse USER', JSON.stringify(DB), error);
-        }
+  //Used as error case or blank
+  constructor(id: number = -1) {
+    this.userID = id;
+    this.isValid = false;
   }
 
-  /* USER ROLE UTILITIES */
-  isRole = (userRole:RoleEnum):boolean => this.userRoleList.includes(userRole) || (this.userRoleList.length === 0 && userRole === RoleEnum.STUDENT);
+  static constructByDatabase = (DB: DATABASE_USER): USER => {
+    try {
+      const newUSER: USER = new USER(DB.userID || -1);
 
-  getHighestRole = ():RoleEnum => Object.values(RoleEnum).reverse()
-                    .find((userRole, index) => (this.isRole(userRole as RoleEnum)))
-                    || RoleEnum.STUDENT; //default
-  
+      newUSER.firstName = DB.firstName;
+      newUSER.lastName = DB.lastName;
+      newUSER.displayName = DB.displayName;
+      newUSER.email = DB.email;
+      newUSER.passwordHash = DB.passwordHash;
+      newUSER.postalCode = DB.postalCode;
+      newUSER.dateOfBirth = DB.dateOfBirth;  //Date converted by MYSQL2
+      newUSER.gender = GenderEnum[DB.gender];
+      newUSER.isActive = DB.isActive ? true : false;
+      newUSER.walkLevel = DB.walkLevel as number;
+      newUSER.image = DB.image;
+      newUSER.notes = DB.notes;
+      newUSER.userRoleList = [RoleEnum[DB.userRole] || RoleEnum.STUDENT];
+      newUSER.isValid = true;
 
-  /* List Utilities */
-  getCircleIDList = ():number[] => this.circleList.map(c => c.circleID);
+      return newUSER;
 
-  getPartnerIDList = ():number[] => this.partnerList.map(p => p.userID);
+    } catch (error) {
+      log.db('INVALID Database Object; failed to parse USER', JSON.stringify(DB), error);
+      return new USER();
+    }
+  }
 
-  getContactIDList = ():number[] => this.contactList.map(u => u.userID);
+  //Clone database model values only (not copying references for ListItems)
+  static constructByClone = (profile: USER): USER => {
+    try { //MUST copy primitives properties directly and create new complex types to avoid reference linking
+      const newUSER: USER = new USER(profile.userID);
 
-  getProfileAccessIDList = ():number[] => this.profileAccessList.map(u => u.userID);
+      if(newUSER.userID > 0) {
+        newUSER.firstName = profile.firstName;
+        newUSER.lastName = profile.lastName;
+        newUSER.displayName = profile.displayName;
+        newUSER.email = profile.email;
+        newUSER.passwordHash = profile.passwordHash;
+        newUSER.postalCode = profile.postalCode;
+        newUSER.dateOfBirth = new Date(profile.dateOfBirth?.getTime());
+        newUSER.gender = GenderEnum[profile.gender];
+        newUSER.isActive = profile.isActive;
+        newUSER.walkLevel = profile.walkLevel;
+        newUSER.image = profile.image;
+        newUSER.notes = profile.notes;
+        newUSER.userRoleList = [...profile.userRoleList];
+        newUSER.isValid = true;
+      }
+
+      return newUSER;
+
+    } catch (error) {
+      log.error('INVALID Object; failed to clone USER', JSON.stringify(profile), error);
+      return new USER();
+    }
+  }
+
+   /* USER ROLE UTILITIES */
+   isRole = (userRole:RoleEnum):boolean => this.userRoleList.includes(userRole) || (this.userRoleList.length === 0 && userRole === RoleEnum.STUDENT);
+
+   getHighestRole = ():RoleEnum => Object.values(RoleEnum).reverse()
+                     .find((userRole, index) => (this.isRole(userRole as RoleEnum)))
+                     || RoleEnum.STUDENT; //default
+   
+ 
+   /* List Utilities */
+   getCircleIDList = ():number[] => this.circleList.map(c => c.circleID);
+ 
+   getPartnerIDList = ():number[] => this.partnerList.map(p => p.userID);
+ 
+   getContactIDList = ():number[] => this.contactList.map(u => u.userID);
+ 
+   getProfileAccessIDList = ():number[] => this.profileAccessList.map(u => u.userID); 
 
   /* PROPERTY FIELD UTILITIES */
-  hasProperty = (field:string) => this.#propertyList.includes(field);
+  static hasProperty = (field:string) => USER.#propertyList.includes(field);
+  hasProperty = (field: string) => USER.#propertyList.includes(field);  //Defined in BASE_MODEL; used for JSON parsing
 
-  getValidProperties = (properties:string[] = this.#userPropertyList, includeUserID:boolean = true):Map<string, any> => {
-      const map = new Map<string, any>();
-      properties.filter((p) => (includeUserID || (p !== 'userID'))).forEach((field) => {
-          if(field === 'userRole') 
-            map.set(field, this.getHighestRole());
-
-          else if(field === 'userRoleList' && this.userRoleList.length === 0) 
-            map.set(field, [this.getHighestRole()]);
-          
-          else if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
-            && (!Array.isArray(this[field]) || this[field].length > 0)) {
-              if(field === 'dateOfBirth')
-                  map.set(field, this.dateOfBirth.toISOString());
-              else
-                  map.set(field, this[field]);
-            }
-      });
-      return map;
-  }
-
-  getUniqueDatabaseProperties = (profile:USER):Map<string, any> => {
+  getValidProperties = (properties:string[] = USER.#userPropertyList, includeUserID:boolean = true):Map<string, any> => {
     const map = new Map<string, any>();
-    USER_TABLE_COLUMNS.filter((c) => ((c !== 'userID'))).forEach((field) => {
-        if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
-            && ((Array.isArray(this[field]) 
-                && (JSON.stringify(Array.from(this[field]).sort()) !== JSON.stringify(Array.from(profile[field]).sort()))) 
-            || (this[field] !== profile[field]))) 
-              map.set(field, this[field]);
+    properties.filter((p) => (includeUserID || (p !== 'userID'))).forEach((field) => {
+        if(field === 'userRole') 
+          map.set(field, this.getHighestRole());
+
+        else if(field === 'userRoleList' && this.userRoleList.length === 0) 
+          map.set(field, [this.getHighestRole()]);
+        
+        else if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
+          && (!Array.isArray(this[field]) || this[field].length > 0)) {
+            if(field === 'dateOfBirth')
+                map.set(field, this.dateOfBirth.toISOString());
+            else
+                map.set(field, this[field]);
+          }
     });
     return map;
   }
 
-  getDatabaseProperties = ():Map<string, any> => this.getUniqueDatabaseProperties(new USER());
+  static getUniqueDatabaseProperties = (editProfile:USER, currentProfile:USER): Map<string, any> => {
+    const map = new Map<string, any>();
+    USER_TABLE_COLUMNS.filter((c) => ((c !== 'userID'))).forEach((field) => {
+      if (field === 'dateOfBirth') { //Must compare dates as numbers
+        if (editProfile.dateOfBirth.getTime() !== currentProfile.dateOfBirth.getTime())
+          map.set(field, editProfile[field]);
 
-  toJSON = ():ProfileResponse => Object.fromEntries(this.getValidProperties(this.#userPropertyList)) as unknown as ProfileResponse;
+      } else if (editProfile.hasOwnProperty(field) && editProfile[field] !== undefined && editProfile[field] !== null
+        && ((Array.isArray(editProfile[field])
+          && (JSON.stringify(Array.from(editProfile[field]).sort()) !== JSON.stringify(Array.from(currentProfile[field]).sort())))
+          || (editProfile[field] !== currentProfile[field])))
+                map.set(field, editProfile[field]);
+    });
+    return map;
+  }
 
-  toPublicJSON = ():ProfilePublicResponse => Object.fromEntries(this.getValidProperties(this.#publicPropertyList)) as unknown as ProfilePublicResponse;
+  getDatabaseProperties = ():Map<string, any> => this.getValidProperties(USER_TABLE_COLUMNS, false);
 
-  toPartnerJSON = ():ProfilePartnerResponse => Object.fromEntries(this.getValidProperties(this.#partnerPropertyList)) as unknown as ProfilePartnerResponse;
+  getDatabaseIdentifyingProperties = ():Map<string, any> => this.getValidProperties(USER.#databaseIdentifyingPropertyList, false);
+
+  toJSON = ():ProfileResponse => Object.fromEntries(this.getValidProperties(USER.#userPropertyList)) as unknown as ProfileResponse;
+
+  toPublicJSON = ():ProfilePublicResponse => Object.fromEntries(this.getValidProperties(USER.#publicPropertyList)) as unknown as ProfilePublicResponse;
+
+  toPartnerJSON = ():ProfilePartnerResponse => Object.fromEntries(this.getValidProperties(USER.#partnerPropertyList)) as unknown as ProfilePartnerResponse;
 
   toListItem = ():ProfileListItem => ({userID: this.userID, firstName: this.firstName, displayName: this.displayName, image: this.image});
 

--- a/1-src/2-services/1-models/userModel.mts
+++ b/1-src/2-services/1-models/userModel.mts
@@ -16,14 +16,15 @@ UNIVERSAl profile for DATABASE OPERATIONS
 export default class USER implements BASE_MODEL {
   modelType = 'USER';
   getID = () => this.userID;
-  setID = (id:number) => this.userID = id;
+  setID = (id: number) => this.userID = id;
   isValid: boolean = false;
 
   //Private static list of class property fields | (This is display-responses; NOT edit-access -> see: profile-field-config.mts)
-  #publicPropertyList = ['userID', 'firstName', 'lastName', 'displayName', 'postalCode', 'dateOfBirth', 'gender', 'image', 'circleList', 'userRole'];
-  #partnerPropertyList = [...this.#publicPropertyList, 'walkLevel'];
-  #userPropertyList = [...this.#partnerPropertyList, 'email', 'isActive', 'notes', 'userRoleList', 'partnerList', 'prayerRequestList', 'contactList', 'profileAccessList'];
-  #propertyList = this.#userPropertyList.filter(property => !['circleList', 'partnerList', 'prayerRequestList', 'contactList'].includes(property)); //Not Edited through Model
+  static #databaseIdentifyingPropertyList = ['firstName', 'lastName', 'displayName', 'email']; //exclude: usedID, complex types, and lists
+  static #publicPropertyList = ['userID', 'firstName', 'lastName', 'displayName', 'postalCode', 'dateOfBirth', 'gender', 'image', 'circleList', 'userRole'];
+  static #partnerPropertyList = [...USER.#publicPropertyList, 'walkLevel'];
+  static #userPropertyList = [...USER.#partnerPropertyList, 'email', 'isActive', 'notes', 'userRoleList', 'partnerList', 'prayerRequestList', 'contactList', 'profileAccessList'];
+  static #propertyList = USER.#userPropertyList.filter(property => !['circleList', 'partnerList', 'prayerRequestList', 'contactList'].includes(property)); //Not Edited through Model
 
   userID: number = -1;
   firstName?: string;
@@ -47,137 +48,180 @@ export default class USER implements BASE_MODEL {
   contactList: ProfileListItem[] = [];
   profileAccessList: ProfileListItem[] = []; //Leaders
 
+  //Used as error case or blank
+  constructor(id: number = -1) {
+    this.userID = id;
+    this.isValid = false;
+  }
 
-  constructor(DB?:DATABASE_USER, userID?:number) {
-        try {
-            this.userID = userID || DB?.userID || -1;
+  static constructByDatabase = (DB: DATABASE_USER): USER => {
+    try {
+      const newUSER: USER = new USER(DB.userID || -1);
 
-            if(DB !== undefined) {
-                this.firstName = DB.firstName;
-                this.lastName = DB.lastName;
-                this.displayName = DB.displayName;
-                this.email = DB.email;
-                this.passwordHash = DB.passwordHash;
-                this.postalCode = DB.postalCode;
-                this.dateOfBirth = DB.dateOfBirth;  //Date converted by MYSQL2
-                this.gender = GenderEnum[DB.gender];
-                this.isActive = DB.isActive ? true : false;
-                this.walkLevel = DB.walkLevel as number;
-                this.image = DB.image;
-                this.notes = DB.notes;
-                this.userRoleList = [RoleEnum[DB.userRole] || RoleEnum.STUDENT];
+      newUSER.firstName = DB.firstName;
+      newUSER.lastName = DB.lastName;
+      newUSER.displayName = DB.displayName;
+      newUSER.email = DB.email;
+      newUSER.passwordHash = DB.passwordHash;
+      newUSER.postalCode = DB.postalCode;
+      newUSER.dateOfBirth = DB.dateOfBirth;  //Date converted by MYSQL2
+      newUSER.gender = GenderEnum[DB.gender];
+      newUSER.isActive = DB.isActive ? true : false;
+      newUSER.walkLevel = DB.walkLevel as number;
+      newUSER.image = DB.image;
+      newUSER.notes = DB.notes;
+      newUSER.userRoleList = [RoleEnum[DB.userRole] || RoleEnum.STUDENT];
+      newUSER.isValid = true;
 
-                this.isValid = true;
-            }
-        } catch(error) {
-            log.db('INVALID Database Object; failed to parse USER', JSON.stringify(DB), error);
-        }
+      return newUSER;
+
+    } catch (error) {
+      log.db('INVALID Database Object; failed to parse USER', JSON.stringify(DB), error);
+      return new USER();
+    }
+  }
+
+  //Clone database model values only (not copying references for ListItems)
+  static constructByClone = (profile: USER): USER => {
+    try { //MUST copy primitives properties directly and create new complex types to avoid reference linking
+      const newUSER: USER = new USER(profile.userID);
+
+      if(newUSER.userID > 0) {
+        newUSER.firstName = profile.firstName;
+        newUSER.lastName = profile.lastName;
+        newUSER.displayName = profile.displayName;
+        newUSER.email = profile.email;
+        newUSER.passwordHash = profile.passwordHash;
+        newUSER.postalCode = profile.postalCode;
+        newUSER.dateOfBirth = new Date(profile.dateOfBirth?.getTime());
+        newUSER.gender = GenderEnum[profile.gender];
+        newUSER.isActive = profile.isActive;
+        newUSER.walkLevel = profile.walkLevel;
+        newUSER.image = profile.image;
+        newUSER.notes = profile.notes;
+        newUSER.userRoleList = [...profile.userRoleList];
+        newUSER.isValid = true;
+      }
+
+      return newUSER;
+
+    } catch (error) {
+      log.error('INVALID Object; failed to clone USER', JSON.stringify(profile), error);
+      return new USER();
+    }
   }
 
   /* USER ROLE UTILITIES */
-  isRole = (userRole:RoleEnum):boolean => this.userRoleList.includes(userRole) || (this.userRoleList.length === 0 && userRole === RoleEnum.STUDENT);
+  isRole = (userRole: RoleEnum): boolean => this.userRoleList.includes(userRole) || (this.userRoleList.length === 0 && userRole === RoleEnum.STUDENT);
 
-  getHighestRole = ():RoleEnum => Object.values(RoleEnum).reverse()
-                    .find((userRole, index) => (this.isRole(userRole as RoleEnum)))
-                    || RoleEnum.STUDENT; //default
-  
+  getHighestRole = (): RoleEnum => Object.values(RoleEnum).reverse()
+    .find((userRole, index) => (this.isRole(userRole as RoleEnum)))
+    || RoleEnum.STUDENT; //default
+
 
   /* List Utilities */
-  getCircleIDList = ():number[] => this.circleList.map(c => c.circleID);
+  getCircleIDList = (): number[] => this.circleList.map(c => c.circleID);
 
-  getPartnerIDList = ():number[] => this.partnerList.map(p => p.userID);
+  getPartnerIDList = (): number[] => this.partnerList.map(p => p.userID);
 
-  getContactIDList = ():number[] => this.contactList.map(u => u.userID);
+  getContactIDList = (): number[] => this.contactList.map(u => u.userID);
 
-  getProfileAccessIDList = ():number[] => this.profileAccessList.map(u => u.userID);
+  getProfileAccessIDList = (): number[] => this.profileAccessList.map(u => u.userID);
 
   /* PROPERTY FIELD UTILITIES */
-  hasProperty = (field:string) => this.#propertyList.includes(field);
+  static hasProperty = (field: string) => USER.#propertyList.includes(field);
+  hasProperty = (field: string) => USER.#propertyList.includes(field);  //Defined in BASE_MODEL; used for JSON parsing
 
-  getValidProperties = (properties:string[] = this.#userPropertyList, includeUserID:boolean = true):Map<string, any> => {
-      const map = new Map<string, any>();
-      properties.filter((p) => (includeUserID || (p !== 'userID'))).forEach((field) => {
-          if(field === 'userRole') 
-            map.set(field, this.getHighestRole());
-
-          else if(field === 'userRoleList' && this.userRoleList.length === 0) 
-            map.set(field, [this.getHighestRole()]);
-          
-          else if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
-            && (!Array.isArray(this[field]) || this[field].length > 0)) {
-              if(field === 'dateOfBirth')
-                  map.set(field, this.dateOfBirth.toISOString());
-              else
-                  map.set(field, this[field]);
-            }
-      });
-      return map;
-  }
-
-  getUniqueDatabaseProperties = (profile:USER):Map<string, any> => {
+  getValidProperties = (properties: string[] = USER.#userPropertyList, includeUserID: boolean = true): Map<string, any> => {
     const map = new Map<string, any>();
-    USER_TABLE_COLUMNS.filter((c) => ((c !== 'userID'))).forEach((field) => {
-        if(this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
-            && ((Array.isArray(this[field]) 
-                && (JSON.stringify(Array.from(this[field]).sort()) !== JSON.stringify(Array.from(profile[field]).sort()))) 
-            || (this[field] !== profile[field]))) 
-              map.set(field, this[field]);
+    properties.filter((p) => (includeUserID || (p !== 'userID'))).forEach((field) => {
+      if (field === 'userRole')
+        map.set(field, this.getHighestRole());
+
+      else if (field === 'userRoleList' && this.userRoleList.length === 0)
+        map.set(field, [this.getHighestRole()]);
+
+      else if (this.hasOwnProperty(field) && this[field] !== undefined && this[field] !== null
+        && (!Array.isArray(this[field]) || this[field].length > 0)) {
+          if (field === 'dateOfBirth')
+            map.set(field, this.dateOfBirth.toISOString());
+          else
+            map.set(field, this[field]);
+        }
     });
     return map;
   }
 
-  getDatabaseProperties = ():Map<string, any> => this.getUniqueDatabaseProperties(new USER());
+  static getUniqueDatabaseProperties = (editProfile:USER, currentProfile:USER): Map<string, any> => {
+    const map = new Map<string, any>();
+    USER_TABLE_COLUMNS.filter((c) => ((c !== 'userID'))).forEach((field) => {
+      if (field === 'dateOfBirth') { //Must compare dates as numbers
+        if (editProfile.dateOfBirth.getTime() !== currentProfile.dateOfBirth.getTime())
+          map.set(field, editProfile[field]);
 
-  toJSON = ():ProfileResponse => Object.fromEntries(this.getValidProperties(this.#userPropertyList)) as unknown as ProfileResponse;
+      } else if (editProfile.hasOwnProperty(field) && editProfile[field] !== undefined && editProfile[field] !== null
+        && ((Array.isArray(editProfile[field])
+          && (JSON.stringify(Array.from(editProfile[field]).sort()) !== JSON.stringify(Array.from(currentProfile[field]).sort())))
+          || (editProfile[field] !== currentProfile[field])))
+                map.set(field, editProfile[field]);
+    });
+    return map;
+  }
 
-  toPublicJSON = ():ProfilePublicResponse => Object.fromEntries(this.getValidProperties(this.#publicPropertyList)) as unknown as ProfilePublicResponse;
+  getDatabaseProperties = (): Map<string, any> => this.getValidProperties(USER_TABLE_COLUMNS, false);
 
-  toPartnerJSON = ():ProfilePartnerResponse => Object.fromEntries(this.getValidProperties(this.#partnerPropertyList)) as unknown as ProfilePartnerResponse;
+  getDatabaseIdentifyingProperties = (): Map<string, any> => this.getValidProperties(USER.#databaseIdentifyingPropertyList, false);
 
-  toListItem = ():ProfileListItem => ({userID: this.userID, firstName: this.firstName, displayName: this.displayName, image: this.image});
+  toJSON = (): ProfileResponse => Object.fromEntries(this.getValidProperties(USER.#userPropertyList)) as unknown as ProfileResponse;
 
-  toString = ():string => JSON.stringify(Object.fromEntries(this.getValidProperties()));
+  toPublicJSON = (): ProfilePublicResponse => Object.fromEntries(this.getValidProperties(USER.#publicPropertyList)) as unknown as ProfilePublicResponse;
+
+  toPartnerJSON = (): ProfilePartnerResponse => Object.fromEntries(this.getValidProperties(USER.#partnerPropertyList)) as unknown as ProfilePartnerResponse;
+
+  toListItem = (): ProfileListItem => ({ userID: this.userID, firstName: this.firstName, displayName: this.displayName, image: this.image });
+
+  toString = (): string => JSON.stringify(Object.fromEntries(this.getValidProperties()));
 
   /** Utility methods for createModelFromJSON **/
-  validateModelSpecificField = ({field, value}:{field:InputField, value:string}):boolean|undefined => {
+  validateModelSpecificField = ({ field, value }: { field: InputField, value: string }): boolean | undefined => {
     /* DATES | dateOfBirth */
-    if(field.type === InputType.DATE && field.field === 'dateOfBirth') { //(Note: Assumes userRoleList has already been parsed or exists)
-      const currentDate:Date = new Date(value);
+    if (field.type === InputType.DATE && field.field === 'dateOfBirth') { //(Note: Assumes userRoleList has already been parsed or exists)
+      const currentDate: Date = new Date(value);
 
-      if(isNaN(currentDate.valueOf()) ||  currentDate < getDOBMinDate(this.getHighestRole()) || currentDate > getDOBMaxDate(this.getHighestRole()))
-          return false;
+      if (isNaN(currentDate.valueOf()) || currentDate < getDOBMinDate(this.getHighestRole()) || currentDate > getDOBMaxDate(this.getHighestRole()))
+        return false;
       else return true;
 
-    } else if(field.field === 'userRoleTokenList') {
-        return (Array.isArray(value)
-                && Array.from(value).every((roleTokenObj:{role:string, token:string}) => {
+    } else if (field.field === 'userRoleTokenList') {
+      return (Array.isArray(value)
+        && Array.from(value).every((roleTokenObj: { role: string, token: string }) => {
 
-                    if(roleTokenObj.role === undefined 
-                      || (roleTokenObj.role.length === 0) 
-                      || !Object.values(RoleEnum).includes(roleTokenObj.role as RoleEnum) 
-                      || roleTokenObj.token === undefined) { //token allowed to be empty string for STUDENT
+          if (roleTokenObj.role === undefined
+            || (roleTokenObj.role.length === 0)
+            || !Object.values(RoleEnum).includes(roleTokenObj.role as RoleEnum)
+            || roleTokenObj.token === undefined) { //token allowed to be empty string for STUDENT
 
-                          log.warn(`Validating error for userRoleTokenList:`, JSON.stringify(roleTokenObj), JSON.stringify(field.selectOptionList));
-                          return false;
-                      } else return true;
-                  }));
+            log.warn(`Validating error for userRoleTokenList:`, JSON.stringify(roleTokenObj), JSON.stringify(field.selectOptionList));
+            return false;
+          } else return true;
+        }));
     }
 
     //No Field Match
     return undefined;
   }
 
-  parseModelSpecificField = ({field, jsonObj}:{field:InputField, jsonObj:ProfileEditRequest['body']}):boolean|undefined => {
+  parseModelSpecificField = ({ field, jsonObj }: { field: InputField, jsonObj: ProfileEditRequest['body'] }): boolean | undefined => {
     //Special Handling: Password Hash
-    if(field.field === 'password' && jsonObj['password'] === jsonObj['passwordVerify']) {
+    if (field.field === 'password' && jsonObj['password'] === jsonObj['passwordVerify']) {
       this.passwordHash = getPasswordHash(jsonObj['password']);
       return true;
 
-    } else if(field.field === 'passwordVerify') { //valid Skip without error
+    } else if (field.field === 'passwordVerify') { //valid Skip without error
       return true;
 
-    } else if(field.field === 'userRoleTokenList') {
-      this.userRoleList = Array.from(jsonObj[field.field] as {role:string, token:string}[]).map(({role, token}) => RoleEnum[role as string] || RoleEnum.STUDENT);
+    } else if (field.field === 'userRoleTokenList') {
+      this.userRoleList = Array.from(jsonObj[field.field] as { role: string, token: string }[]).map(({ role, token }) => RoleEnum[role as string] || RoleEnum.STUDENT);
       return true;
     }
 

--- a/1-src/2-services/1-models/userModel.mts
+++ b/1-src/2-services/1-models/userModel.mts
@@ -16,7 +16,7 @@ UNIVERSAl profile for DATABASE OPERATIONS
 export default class USER implements BASE_MODEL {
   modelType = 'USER';
   getID = () => this.userID;
-  setID = (id: number) => this.userID = id;
+  setID = (id:number) => this.userID = id;
   isValid: boolean = false;
 
   //Private static list of class property fields | (This is display-responses; NOT edit-access -> see: profile-field-config.mts)
@@ -54,7 +54,7 @@ export default class USER implements BASE_MODEL {
     this.isValid = false;
   }
 
-  static constructByDatabase = (DB: DATABASE_USER): USER => {
+  static constructByDatabase = (DB:DATABASE_USER): USER => {
     try {
       const newUSER: USER = new USER(DB.userID || -1);
 
@@ -152,7 +152,7 @@ export default class USER implements BASE_MODEL {
     return map;
   }
 
-  static getUniqueDatabaseProperties = (editProfile:USER, currentProfile:USER): Map<string, any> => {
+  static getUniqueDatabaseProperties = (editProfile:USER, currentProfile:USER):Map<string, any> => {
     const map = new Map<string, any>();
     USER_TABLE_COLUMNS.filter((c) => ((c !== 'userID'))).forEach((field) => {
       if (field === 'dateOfBirth') { //Must compare dates as numbers
@@ -178,25 +178,25 @@ export default class USER implements BASE_MODEL {
 
   toPartnerJSON = ():ProfilePartnerResponse => Object.fromEntries(this.getValidProperties(USER.#partnerPropertyList)) as unknown as ProfilePartnerResponse;
 
-  toListItem = (): ProfileListItem => ({ userID: this.userID, firstName: this.firstName, displayName: this.displayName, image: this.image });
+  toListItem = ():ProfileListItem => ({userID: this.userID, firstName: this.firstName, displayName: this.displayName, image: this.image});
 
-  toString = (): string => JSON.stringify(Object.fromEntries(this.getValidProperties()));
+  toString = ():string => JSON.stringify(Object.fromEntries(this.getValidProperties()));
 
   /** Utility methods for createModelFromJSON **/
-  validateModelSpecificField = ({ field, value }: { field: InputField, value: string }): boolean | undefined => {
+  validateModelSpecificField = ({field, value}:{field:InputField, value:string}):boolean|undefined => {
     /* DATES | dateOfBirth */
-    if (field.type === InputType.DATE && field.field === 'dateOfBirth') { //(Note: Assumes userRoleList has already been parsed or exists)
-      const currentDate: Date = new Date(value);
+    if(field.type === InputType.DATE && field.field === 'dateOfBirth') { //(Note: Assumes userRoleList has already been parsed or exists)
+      const currentDate:Date = new Date(value);
 
-      if (isNaN(currentDate.valueOf()) || currentDate < getDOBMinDate(this.getHighestRole()) || currentDate > getDOBMaxDate(this.getHighestRole()))
+      if(isNaN(currentDate.valueOf()) || currentDate < getDOBMinDate(this.getHighestRole()) || currentDate > getDOBMaxDate(this.getHighestRole()))
         return false;
       else return true;
 
     } else if (field.field === 'userRoleTokenList') {
       return (Array.isArray(value)
-        && Array.from(value).every((roleTokenObj: { role: string, token: string }) => {
+        && Array.from(value).every((roleTokenObj:{role:string, token:string}) => {
 
-          if (roleTokenObj.role === undefined
+          if(roleTokenObj.role === undefined
             || (roleTokenObj.role.length === 0)
             || !Object.values(RoleEnum).includes(roleTokenObj.role as RoleEnum)
             || roleTokenObj.token === undefined) { //token allowed to be empty string for STUDENT
@@ -211,17 +211,17 @@ export default class USER implements BASE_MODEL {
     return undefined;
   }
 
-  parseModelSpecificField = ({ field, jsonObj }: { field: InputField, jsonObj: ProfileEditRequest['body'] }): boolean | undefined => {
+  parseModelSpecificField = ({field, jsonObj}:{field:InputField, jsonObj:ProfileEditRequest['body'] }):boolean|undefined => {
     //Special Handling: Password Hash
-    if (field.field === 'password' && jsonObj['password'] === jsonObj['passwordVerify']) {
+    if(field.field === 'password' && jsonObj['password'] === jsonObj['passwordVerify']) {
       this.passwordHash = getPasswordHash(jsonObj['password']);
       return true;
 
-    } else if (field.field === 'passwordVerify') { //valid Skip without error
+    } else if(field.field === 'passwordVerify') { //valid Skip without error
       return true;
 
-    } else if (field.field === 'userRoleTokenList') {
-      this.userRoleList = Array.from(jsonObj[field.field] as { role: string, token: string }[]).map(({ role, token }) => RoleEnum[role as string] || RoleEnum.STUDENT);
+    } else if(field.field === 'userRoleTokenList') {
+      this.userRoleList = Array.from(jsonObj[field.field] as {role:string, token:string}[]).map(({role, token}) => RoleEnum[role as string] || RoleEnum.STUDENT);
       return true;
     }
 

--- a/1-src/2-services/2-database/queries/circle-queries.mts
+++ b/1-src/2-services/2-database/queries/circle-queries.mts
@@ -40,7 +40,7 @@ export const DB_SELECT_CIRCLE = async(circleID:number):Promise<CIRCLE> => {
         return new CIRCLE(undefined);
     }
     
-    return new CIRCLE(rows[0] as DATABASE_CIRCLE); 
+    return CIRCLE.constructByDatabase(rows[0] as DATABASE_CIRCLE); 
 }
 
 //Includes circle, leader profile, and requestor status
@@ -57,7 +57,7 @@ export const DB_SELECT_CIRCLE_DETAIL = async({userID, circleID}:{userID?:number,
         return new CIRCLE(undefined);
     }
     
-    const circle = new CIRCLE(rows[0] as DATABASE_CIRCLE); 
+    const circle = CIRCLE.constructByDatabase(rows[0] as DATABASE_CIRCLE); 
     circle.requestorID = userID;
     circle.requestorStatus = (userID === circle.leaderID) ? CircleStatusEnum.LEADER : CircleStatusEnum[rows[0].status];
     circle.leaderProfile = {userID: rows[0].leaderID, firstName: rows[0].leaderFirstName, displayName: rows[0].leaderDisplayName, image: rows[0].leaderImage};
@@ -78,7 +78,7 @@ export const DB_SELECT_CIRCLE_DETAIL_BY_NAME = async(circleName:string):Promise<
         return new CIRCLE(undefined);
     }
     
-    const circle = new CIRCLE(rows[0] as DATABASE_CIRCLE); 
+    const circle = CIRCLE.constructByDatabase(rows[0] as DATABASE_CIRCLE); 
     circle.leaderProfile = {userID: rows[0].leaderID, firstName: rows[0].leaderFirstName, displayName: rows[0].leaderDisplayName, image: rows[0].leaderImage};
 
     return circle;
@@ -218,7 +218,7 @@ export const DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT = async(circleID:number):Prom
         + 'WHERE circleID = ? '                                              //TODO: Filter for current: ' AND startDate < ? AND endDate > ? '
         + 'ORDER BY startDate ASC;', [circleID]);
 
-    return [...rows.map(row => (new CIRCLE_ANNOUNCEMENT(row as DATABASE_CIRCLE_ANNOUNCEMENT)))];
+    return [...rows.map(row => (CIRCLE_ANNOUNCEMENT.constructByDatabase(row as DATABASE_CIRCLE_ANNOUNCEMENT)))];
 }
 
 export const DB_INSERT_CIRCLE_ANNOUNCEMENT = async(fieldMap:Map<string, any>):Promise<boolean> => {

--- a/1-src/2-services/2-database/queries/prayer-request-queries.mts
+++ b/1-src/2-services/2-database/queries/prayer-request-queries.mts
@@ -1,7 +1,7 @@
 import { CircleListItem } from '../../../0-assets/field-sync/api-type-sync/circle-types.mjs';
 import { PrayerRequestCommentListItem, PrayerRequestListItem } from '../../../0-assets/field-sync/api-type-sync/prayer-request-types.mjs';
 import { ProfileListItem } from '../../../0-assets/field-sync/api-type-sync/profile-types.mjs';
-import PRAYER_REQUEST, { prayerRequestParseTags } from '../../1-models/prayerRequestModel.mjs';
+import PRAYER_REQUEST from '../../1-models/prayerRequestModel.mjs';
 import * as log from '../../log.mjs';
 import { CommandResponseType, DATABASE_PRAYER_REQUEST, PRAYER_REQUEST_TABLE_COLUMNS, PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED } from '../database-types.mjs';
 import { batch, command, execute, query, validateColumns } from '../database.mjs';
@@ -37,7 +37,7 @@ export const DB_SELECT_PRAYER_REQUEST = async(prayerRequestID:number):Promise<PR
         return new PRAYER_REQUEST(undefined);
     }
     
-    return new PRAYER_REQUEST(rows[0] as DATABASE_PRAYER_REQUEST); 
+    return PRAYER_REQUEST.constructByDatabase(rows[0] as DATABASE_PRAYER_REQUEST); 
 }
 
 //Includes: prayer_request, requestorProfile, commentList, userRecipientList, circleRecipientList
@@ -53,7 +53,7 @@ export const DB_SELECT_PRAYER_REQUEST_DETAIL = async(prayerRequestID:number, inc
         return new PRAYER_REQUEST(undefined);
     }
     
-    const prayerRequest = new PRAYER_REQUEST(rows[0] as DATABASE_PRAYER_REQUEST); 
+    const prayerRequest = PRAYER_REQUEST.constructByDatabase(rows[0] as DATABASE_PRAYER_REQUEST); 
     prayerRequest.requestorProfile = {userID: rows[0].requestorID, firstName: rows[0].requestorFirstName, displayName: rows[0].requestorDisplayName, image: rows[0].requestorImage};
     prayerRequest.commentList = await DB_SELECT_PRAYER_REQUEST_COMMENT_LIST(prayerRequestID);
 
@@ -107,7 +107,7 @@ export const DB_INSERT_AND_SELECT_PRAYER_REQUEST = async(fieldMap:Map<string, an
         return new PRAYER_REQUEST(undefined);
     }
 
-    const prayerRequest = new PRAYER_REQUEST(rows[0] as DATABASE_PRAYER_REQUEST); 
+    const prayerRequest = PRAYER_REQUEST.constructByDatabase(rows[0] as DATABASE_PRAYER_REQUEST); 
     prayerRequest.requestorProfile = {userID: rows[0].requestorID, firstName: rows[0].requestorFirstName, displayName: rows[0].requestorDisplayName, image: rows[0].requestorImage};
     return prayerRequest; 
 }
@@ -184,7 +184,7 @@ export const DB_SELECT_PRAYER_REQUEST_USER_LIST = async(userID:number):Promise<P
     + 'WHERE prayer_request_recipient.userID = ? OR circle_user.userID = ? OR circle.leaderID = ? '
     + 'ORDER BY prayer_request.modifiedDT ASC LIMIT 30;', [userID, userID, userID]); 
  
-    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: prayerRequestParseTags(row.tagsStringified),
+    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: PRAYER_REQUEST.prayerRequestParseTags(row.tagsStringified),
             requestorProfile: {userID: row.requestorID, firstName: row.requestorFirstName, displayName: row.requestorDisplayName, image: row.requestorImage}}))];
 }
 
@@ -198,7 +198,7 @@ export const DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST = async(circleID:number):Promi
     + 'WHERE prayer_request_recipient.circleID = ? '
     + 'ORDER BY prayer_request.modifiedDT ASC LIMIT 30;', [circleID]); 
  
-    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: prayerRequestParseTags(row.tagsStringified),
+    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: PRAYER_REQUEST.prayerRequestParseTags(row.tagsStringified),
             requestorProfile: {userID: row.requestorID, firstName: row.requestorFirstName, displayName: row.requestorDisplayName, image: row.requestorImage}}))];
 }
 
@@ -219,7 +219,7 @@ export const DB_SELECT_PRAYER_REQUEST_REQUESTOR_LIST = async(userID:number, isRe
             + 'WHERE requestorID = ? '
             + 'ORDER BY prayer_request.modifiedDT ASC LIMIT 30;', [userID]); 
  
-    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: prayerRequestParseTags(row.tagsStringified),
+    return [...rows.map(row => ({prayerRequestID: row.prayerRequestID || -1, topic: row.topic || '', prayerCount: row.prayerCount || 0, tagList: PRAYER_REQUEST.prayerRequestParseTags(row.tagsStringified),
             requestorProfile: {userID: row.requestorID, firstName: row.requestorFirstName, displayName: row.requestorDisplayName, image: row.requestorImage}}))];
 }
 

--- a/1-src/2-services/2-database/queries/user-queries.mts
+++ b/1-src/2-services/2-database/queries/user-queries.mts
@@ -48,7 +48,7 @@ export const DB_SELECT_USER = async(filterMap:Map<string, any>):Promise<USER> =>
         + 'LEFT JOIN user_role_defined ON user_role_defined.userRoleID = user_role.userRoleID '
         + `WHERE ${preparedColumns};`, Array.from(filterMap.values()));
     
-    if(rows.length === 1) return new USER(rows[0] as DATABASE_USER);
+    if(rows.length === 1) return USER.constructByDatabase(rows[0] as DATABASE_USER);
     else {
         log.error(`DB_SELECT_USER ${rows.length ? 'MULTIPLE' : 'NONE'} USERS IDENTIFIED`, JSON.stringify(filterMap), JSON.stringify(rows));
         return new USER();
@@ -73,7 +73,7 @@ export const DB_SELECT_USER_PROFILE = async(filterMap:Map<string, any>):Promise<
     }
     
     //Append Full Profile 
-    const user = new USER(rows[0] as DATABASE_USER);
+    const user = USER.constructByDatabase(rows[0] as DATABASE_USER);
     user.userRoleList = await DB_SELECT_USER_ROLES(user.userID);
     user.circleList = await DB_SELECT_USER_CIRCLES(user.userID);  //Includes all statuses
     user.partnerList = await DB_SELECT_USER_PARTNERS(user.userID);

--- a/1-src/2-services/createModelFromJSON.mts
+++ b/1-src/2-services/createModelFromJSON.mts
@@ -20,18 +20,16 @@ const getNewModel = (existingModel:BASE_MODEL):ModelTypes|undefined => {
     if(existingModel !== undefined)
         switch (existingModel.modelType) {
             case 'USER':
-                const user = new USER(undefined, (existingModel as USER).userID);
-                user.userRoleList = (existingModel as USER).userRoleList;
-                return user;
+                return USER.constructByClone(existingModel as USER);
 
             case 'CIRCLE':
-                return new CIRCLE(undefined, (existingModel as CIRCLE).circleID);
+                return CIRCLE.constructByClone(existingModel as CIRCLE);
 
             case 'CIRCLE_ANNOUNCEMENT':
                 return new CIRCLE_ANNOUNCEMENT(undefined);
 
             case 'PRAYER_REQUEST':
-                return new PRAYER_REQUEST(undefined, (existingModel as PRAYER_REQUEST).prayerRequestID);
+                return PRAYER_REQUEST.constructByClone(existingModel as PRAYER_REQUEST);
 
             default:
                 log.error('createModelFromJson.getNewModel | modelType not defined', existingModel.modelType);


### PR DESCRIPTION
[Trello: 68 Model Cloning.](https://trello.com/c/sBHt9WSq/68-68-server-model-cloning)

**Context:**  This refactor started with getting full model response for `PATCH request` from [Trello: 67 Mobile Edit Profile](https://trello.com/c/MkFB8eNV/67-67-mobile-refactor-edit-profile).  However I quickly discovered the values weren't available because the comparison to the current model didn't work either.  Eventually traced back to  an inaccurate cloning of the current model before JSON body is applied.

I learned a few things about JavaScript
- `static methods` and fields aren't allowed in an `interface` (so I'll have to remember when making new models)
- `abstract` classes can be extended and have `static methods`; but these `static methods` belong to the parent and an override is not required nor inherited.
- `private class properties` don't technically exist; however typescript attempts to enforce with `#field` or `_filed`
- `this` keyword is treated like an object; so `new model = { ...this }` passes primitive types as a reference; resulting in odd behavior where `modelA.field !== modelB.field` but `this['field'] === modelB.field`

**Key Changes Below:**
1. Each Model has three constructors
    1.  constructor(id)
    2. static constructByDatabase(DB)
    3. static constructByClone(model)
4.  Property lists are also now `static` to be referenced by `static methods` and saved memory
5. Re-defined Methods
    6. `static getUniqueDatabaseProperties()` : Compares models and returns map of first models unique values
    7. `getDatabaseIdentifyingProperties()` : Used in POST to search database without ID
    8. `getDatabaseProperties()` : Used to get non null values to save to database in POST

9. Lots of updating references with the change to static