### PR TITLE
[62]-Image POST return only file path

### DIFF
--- a/1-src/1-api/3-profile/profile.mts
+++ b/1-src/1-api/3-profile/profile.mts
@@ -205,7 +205,7 @@ export const GET_profileImage = async(request: JwtClientRequest, response: Respo
 
 /* Headers: Content-Type: 'image/jpg' or 'image/png' & Content-Length: (calculated) | Body: binary: Blob */
 export const POST_profileImage = async(request: ProfileImageRequest, response: Response, next: NextFunction) => {
-    const fileName:string = request.params.file || 'invalid';
+    const fileName:string = request.params.file || 'invalid'; //Necessary to parse file extension
     const fileExtension:string = fileName.split('.').pop();
     let filePath:string|undefined = undefined;
 
@@ -223,7 +223,7 @@ export const POST_profileImage = async(request: ProfileImageRequest, response: R
         next(new Exception(500, `Profile image upload failed to save: ${filePath}`, 'Save Failed'));
 
     else
-        response.status(202).send(`Successfully saved profile image: ${filePath}`);
+        response.status(202).send(filePath);
 }
 
 export const DELETE_profileImage = async(request: JwtClientRequest, response: Response, next: NextFunction) => {

--- a/1-src/1-api/4-circle/circle.mts
+++ b/1-src/1-api/4-circle/circle.mts
@@ -173,7 +173,7 @@ export const GET_circleImage = async(request: JwtCircleRequest, response: Respon
 }
 
 export const POST_circleImage = async(request: CircleImageRequest, response: Response, next: NextFunction) => {
-    const fileName:string = request.params.file || 'invalid';
+    const fileName:string = request.params.file || 'invalid'; //Necessary to parse file extension
     const fileExtension:string = fileName.split('.').pop();
     let filePath:string|undefined = undefined;
 
@@ -191,7 +191,7 @@ export const POST_circleImage = async(request: CircleImageRequest, response: Res
         next(new Exception(500, `Circle Profile image upload failed to save: ${filePath}`, 'Save Failed'));
 
     else
-        response.status(202).send(`Successfully saved circle profile image: ${filePath}`);
+        response.status(202).send(filePath);
 }
 
 export const DELETE_circleImage = async(request: JwtCircleRequest, response: Response, next: NextFunction) => {


### PR DESCRIPTION
For both Profile and Circle Image Upload, the new URL for the image is returned from a successful POST.
<img width="987" alt="Screenshot 2023-12-26 at 11 13 18 AM" src="https://github.com/PEW35MINISTRY/server/assets/53985473/14b299b6-33d3-4f9f-b236-11d8abb2ffb1">
