### PR TITLE
[48] Update Prayer Request and Comment Response

### DIFF
--- a/1-src/0-assets/field-sync/api-type-sync/prayer-request-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/prayer-request-types.mts
@@ -40,8 +40,6 @@ export interface PrayerRequestResponseBody {
     commentList?: PrayerRequestCommentListItem[],
     userRecipientList?: number[],
     circleRecipientList?: number[],
-    addCircleRecipientIDList?: number[],
-    removeCircleRecipientIDList?: number[]
 }
 
 export interface PrayerRequestPostRequestBody {

--- a/1-src/2-services/2-database/queries/prayer-request-queries.mts
+++ b/1-src/2-services/2-database/queries/prayer-request-queries.mts
@@ -346,6 +346,25 @@ export const DB_SELECT_PRAYER_REQUEST_COMMENT_LIST = async(prayerRequestID:numbe
             commenterProfile: {userID: row.commenterID, firstName: row.commenterFirstName, displayName: row.commenterDisplayName, image: row.commenterImage}}))];
 }
 
+//Used to identify commentID
+export const DB_SELECT_PRAYER_REQUEST_COMMENT = async({prayerRequestID, commenterID, message}:{prayerRequestID:number, commenterID:number, message:string}):Promise<PrayerRequestCommentListItem|undefined> => {
+    const rows = await execute('SELECT prayer_request_comment.*, '
+    + 'user.firstName as commenterFirstName, user.displayName as commenterDisplayName, user.image as commenterImage '
+    + 'FROM prayer_request_comment '
+    + 'LEFT JOIN user ON user.userID = prayer_request_comment.commenterID '
+    + 'WHERE prayerRequestID = ? AND prayer_request_comment.commenterID = ? AND prayer_request_comment.message = ?;',
+      [prayerRequestID, commenterID, message]); 
+
+    if(rows.length === 1) 
+        return ({commentID: rows[0].commentID || -1, prayerRequestID: rows[0].prayerRequestID || -1, message: rows[0].message || '', likeCount: rows[0].likeCount || 0,
+                commenterProfile: {userID: rows[0].commenterID, firstName: rows[0].commenterFirstName, displayName: rows[0].commenterDisplayName, image: rows[0].commenterImage}});
+
+    else {
+        log.error(`DB_SELECT_PRAYER_REQUEST_COMMENT ${rows.length ? 'MULTIPLE' : 'NONE'} COMMENTS IDENTIFIED`, prayerRequestID, commenterID, message, JSON.stringify(rows));
+        return undefined;
+    }
+}
+
 export const DB_INSERT_PRAYER_REQUEST_COMMENT = async({prayerRequestID, commenterID, message}:{prayerRequestID:number, commenterID:number, message:string}):Promise<boolean> => {
     const response:CommandResponseType = await command(`INSERT INTO prayer_request_comment ( prayerRequestID, commenterID, message ) VALUES ( ?, ?, ? );`, [prayerRequestID, commenterID, message]);
 

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -23,7 +23,7 @@ import { GET_userContacts } from './1-api/7-chat/chat.mjs';
 import { GET_allUserCredentials, GET_jwtVerify, POST_login, POST_logout, POST_authorization_reset } from './1-api/2-auth/auth.mjs';
 import { GET_EditProfileFields, GET_partnerProfile, GET_profileAccessUserList, GET_publicProfile, GET_RoleList, GET_SignupProfileFields, GET_userProfile, PATCH_userProfile, GET_AvailableAccount, DELETE_userProfile, POST_profileImage, DELETE_profileImage, GET_profileImage, DELETE_flushClientSearchCache, POST_signup } from './1-api/3-profile/profile.mjs';
 import { GET_circle, POST_newCircle, DELETE_circle, DELETE_circleLeaderMember, DELETE_circleMember, PATCH_circle, POST_circleLeaderAccept, POST_circleMemberAccept, POST_circleMemberJoinAdmin, POST_circleMemberRequest, POST_circleLeaderMemberInvite, DELETE_circleAnnouncement, POST_circleAnnouncement, POST_circleImage, DELETE_circleImage, GET_circleImage, DELETE_flushCircleSearchCache } from './1-api/4-circle/circle.mjs';
-import { DELETE_prayerRequest, DELETE_prayerRequestComment, GET_PrayerRequest, GET_PrayerRequestRequestorDetails, GET_PrayerRequestCircleList, GET_PrayerRequestRequestorList, GET_PrayerRequestRequestorResolvedList, GET_PrayerRequestUserList, PATCH_prayerRequest, POST_prayerRequest, POST_prayerRequestComment, POST_prayerRequestCommentIncrementLikeCount, POST_prayerRequestIncrementPrayerCount, POST_prayerRequestResolved } from './1-api/5-prayer-request/prayer-request.mjs';
+import { DELETE_prayerRequest, DELETE_prayerRequestComment, GET_PrayerRequest, GET_PrayerRequestCircleList, GET_PrayerRequestRequestorList, GET_PrayerRequestRequestorResolvedList, GET_PrayerRequestUserList, PATCH_prayerRequest, POST_prayerRequest, POST_prayerRequestComment, POST_prayerRequestCommentIncrementLikeCount, POST_prayerRequestIncrementPrayerCount, POST_prayerRequestResolved } from './1-api/5-prayer-request/prayer-request.mjs';
 import { DELETE_contentArchive, GET_ContentRequest, PATCH_contentArchive, POST_newContentArchive } from './1-api/11-content/content.mjs';
 
 //Import Services
@@ -170,7 +170,7 @@ apiServer.delete('/api/prayer-request/:prayer/comment/:comment', DELETE_prayerRe
 /*****************************************************************************/
 apiServer.use('/api/prayer-request-edit/:prayer', (request:JwtPrayerRequest, response:Response, next:NextFunction) => authenticatePrayerRequestRequestorMiddleware(request, response, next));
 
-apiServer.get('/api/prayer-request-edit/:prayer', GET_PrayerRequestRequestorDetails);
+apiServer.get('/api/prayer-request-edit/:prayer', GET_PrayerRequest);
 apiServer.patch('/api/prayer-request-edit/:prayer', PATCH_prayerRequest);
 apiServer.post('/api/prayer-request-edit/:prayer/resolved', POST_prayerRequestResolved);
 apiServer.delete('/api/prayer-request-edit/:prayer', DELETE_prayerRequest);


### PR DESCRIPTION
## #48 Prayer Request Response Update
- Remove unneeded types from `PrayerRequestResponseBody`
- Both Prayer Request GET return recipients
- POST Prayer  Request Comment returns `PrayerRequestCommentListItem` including `commentID`