### PR TITLE
Implemented Secrets Manager pull for jwt secret key

### DIFF
--- a/1-src/1-api/2-auth/auth-utilities.mts
+++ b/1-src/1-api/2-auth/auth-utilities.mts
@@ -46,7 +46,7 @@ export const generateJWT = (userID:number, userRole:RoleEnum):string => {
     //generate JWT as type JWTData
     if(userID > 0 && userRole as RoleEnum !== undefined)
         // default config generates signature with HS256 - https://www.npmjs.com/package/jsonwebtoken
-        return jwtPackage.sign({jwtUserID: userID, jwtUserRole: userRole}, APP_SECRET_KEY, {expiresIn: '2 days'});
+        return jwtPackage.sign({jwtUserID: userID, jwtUserRole: userRole}, APP_SECRET_KEY, {expiresIn: process.env.JWT_DURATION || '15 minutes'});
     else {
         log.error(`JWT Generation Failed: INVALID userID: ${userID} or userRole: ${userRole}`);
         return '';


### PR DESCRIPTION
Using the same logic as the RDS database, we can pull the secret used to sign JWTs from secrets manager.

I implemented it such that it pulls the secret from ENV if the development is dev, if production it will pull it from Secrets Manager.

I plan on generating the secret key via KMS's GenerateDataKey API - https://docs.aws.amazon.com/cli/latest/reference/kms/generate-data-key.html
This will make it so that the key is the same every time the server restarts unless we change the key on the Secrets Manager side.

Let me know what you think.