### PR TITLE
Signup Content List

### DIFF
--- a/1-src/1-api/2-auth/auth-utilities.mts
+++ b/1-src/1-api/2-auth/auth-utilities.mts
@@ -9,6 +9,7 @@ import * as log from '../../2-services/log.mjs';
 import { JwtData } from './auth-types.mjs';
 import { LoginResponseBody } from '../../0-assets/field-sync/api-type-sync/auth-types.mjs';
 import { GetSecretValueCommand, GetSecretValueResponse, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+import { DB_SELECT_USER_CONTENT_LIST } from '../../2-services/2-database/queries/content-queries.mjs';
 dotenv.config(); 
 
 /********************
@@ -136,6 +137,10 @@ export const getUserLogin = async(email:string = '', password: string = '', deta
     const passwordHash:string = getPasswordHash(password);
     const userProfile:USER = detailed ? await DB_SELECT_USER_PROFILE(new Map([['email', email], ['passwordHash', passwordHash]]))
     : await DB_SELECT_USER(new Map([['email', email], ['passwordHash', passwordHash]]));
+
+    //Always include default content for dashboard
+    if(userProfile.recommendedContentList === undefined || userProfile.recommendedContentList.length === 0)
+        userProfile.recommendedContentList = await DB_SELECT_USER_CONTENT_LIST(userProfile.userID, 5);
 
     if(userProfile.userID > 0) {
         log.auth('Successfully logged in user: ', userProfile.userID);

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -120,12 +120,12 @@ apiServer.use(express.json());
 
 apiServer.post('/subscribe', POST_emailSubscribe);
 
-apiServer.post('/signup', POST_signup);
-
 apiServer.get('/resources/role-list', GET_RoleList);
 apiServer.get('/resources/available-account', GET_AvailableAccount);
 
 apiServer.get('/resources/signup-fields/:role?', GET_SignupProfileFields);
+
+apiServer.post('/signup', POST_signup);
 
 apiServer.post('/login', POST_login);
 


### PR DESCRIPTION
### Ensure User login and signup always include content list

I choose to put patch in `getUserLogin` to get the content list.
- Because that's right before profile is converted to JSON and returned to `/POST_signup`
- Also, I didn't want to use `DB_SELECT_USER_PROFILE` which would waist a lot of empty queries of the other tables