### PR TITLE
[115]  Adding ownedPrayerRequestList

### DIFF
--- a/1-src/0-assets/field-sync/api-type-sync/profile-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/profile-types.mts
@@ -66,7 +66,7 @@ export const PROFILE_PROPERTY_LIST = [ //Sync to ProfileResponse
     'userRole', 'userRoleList',
     'circleList', 'circleInviteList', 'circleRequestList', 'circleAnnouncementList',
     'partnerList', 'partnerPendingUserList', 'partnerPendingPartnerList',
-    'newPrayerRequestList', 'recommendedContentList', 'contactList', 'profileAccessList'
+    'newPrayerRequestList', 'ownedPrayerRequestList', 'recommendedContentList', 'contactList', 'profileAccessList'
 ];
 
 export interface ProfileResponse {
@@ -93,6 +93,7 @@ export interface ProfileResponse {
     partnerPendingUserList?: PartnerListItem[],
     partnerPendingPartnerList?: PartnerListItem[],
     newPrayerRequestList?: PrayerRequestListItem[], //Recipient for dashboard
+    ownedPrayerRequestList?: PrayerRequestListItem[], //Not resolved (pending) for which user is the Requestor
     recommendedContentList?: ContentListItem[],
     contactList?: ProfileListItem[],
     profileAccessList?: ProfileListItem[], //Leaders

--- a/1-src/2-services/1-models/userModel.mts
+++ b/1-src/2-services/1-models/userModel.mts
@@ -54,6 +54,7 @@ export default class USER extends BASE_MODEL<USER, ProfileListItem, ProfileRespo
   partnerPendingUserList: PartnerListItem[] = [];    //Transformed in DB to USER perspective | Includes: PENDING_CONTRACT_USER, PENDING_CONTRACT_BOTH
   partnerPendingPartnerList: PartnerListItem[] = []; //Transformed in DB to USER perspective | Includes: PENDING_CONTRACT_PARTNER
   newPrayerRequestList: PrayerRequestListItem[] = [];   //Recipient for dashboard preview
+  ownedPrayerRequestList: PrayerRequestListItem[] = []; //Not resolved (pending) for which user is the Requestor
   recommendedContentList: ContentListItem[] = [];
   contactList: ProfileListItem[] = [];
   profileAccessList: ProfileListItem[] = []; //Leaders

--- a/1-src/2-services/2-database/queries/circle-queries.mts
+++ b/1-src/2-services/2-database/queries/circle-queries.mts
@@ -216,7 +216,7 @@ export const DB_DELETE_CIRCLE_SEARCH_REVERSE_CACHE = async(filterList:CircleSear
  *******************************/
 export const DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT = async(circleID:number):Promise<CIRCLE_ANNOUNCEMENT[]> => {
     const currentDate:Date = new Date();
-    const rows = await execute('SELECT * ' + 'FROM circle_announcement '
+    const rows = await execute('SELECT circle_announcement.* ' + 'FROM circle_announcement '
         + 'WHERE circleID = ? '
         + 'AND circle_announcement.startDate < ? '
         // + 'AND circle_announcement.endDate > ? ' //TODO enable once we have auto delete routines
@@ -227,7 +227,7 @@ export const DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT = async(circleID:number):Prom
 
 export const DB_SELECT_CIRCLE_ANNOUNCEMENT_ALL_CIRCLES = async(userID:number):Promise<CIRCLE_ANNOUNCEMENT[]> => {
     const currentDate:Date = new Date();
-    const rows = await execute('SELECT * ' + 'FROM circle_announcement '
+    const rows = await execute('SELECT DISTINCT circle_announcement.* ' + 'FROM circle_announcement '
         + 'LEFT JOIN circle ON circle_announcement.circleID = circle.circleID '
         + 'LEFT JOIN circle_user ON circle_announcement.circleID = circle_user.circleID '
         + 'WHERE (( circle_user.userID = ? AND circle_user.status = ? ) OR circle.leaderID = ? ) '

--- a/1-src/2-services/2-database/queries/user-queries.mts
+++ b/1-src/2-services/2-database/queries/user-queries.mts
@@ -92,6 +92,7 @@ export const DB_SELECT_USER_PROFILE = async(filterMap:Map<string, any>):Promise<
     user.partnerPendingPartnerList = allPartnerList.filter(partner => (partner.status === PartnerStatusEnum.PENDING_CONTRACT_PARTNER));
 
     user.newPrayerRequestList = await DB_SELECT_PRAYER_REQUEST_USER_LIST(user.userID, 7); //recipient, dashboard preview
+    user.ownedPrayerRequestList = await DB_SELECT_PRAYER_REQUEST_REQUESTOR_LIST(user.userID, false); //Not resolved (pending) for which user is the Requestor
     user.recommendedContentList = await DB_SELECT_USER_CONTENT_LIST(user.userID, 5);
 
     user.contactList = await DB_SELECT_CONTACTS(user.userID);


### PR DESCRIPTION
# Changes:
1. Adding `ownedPrayerRequestList` to user model and login response.  These are prayer request that are pending (not resolved) and owned by the user
2. Corrected Circle Announcements returning duplicates


***Note: Copy over `profile-types.mts` to mobile