### PR TITLE
154 notifs ios

### DIFF
--- a/1-src/0-assets/field-sync/api-type-sync/notification-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/notification-types.mts
@@ -1,6 +1,8 @@
 
 /*********** ONLY DEPENDENCIES FROM DIRECTORY: /field-sync/ ***********/
 
+import { DeviceOSEnum } from "../input-config-sync/inputField.mjs"
+
 
 /************************************************************
 *    NOTIFICATION DEVICE TYPE CONFIGURATION FILE            *
@@ -15,8 +17,8 @@ export type NotificationDeviceVerify = {
 
 export type NotificationDeviceSignup = {
     deviceToken: string,
+    deviceOS: DeviceOSEnum,
     deviceName?: string,
-    deviceOS?: string
 }
 
 export interface NotificationDeviceListItem {

--- a/1-src/0-assets/field-sync/input-config-sync/notification-field-config.mts
+++ b/1-src/0-assets/field-sync/input-config-sync/notification-field-config.mts
@@ -10,7 +10,8 @@ import InputField, { InputType } from './inputField.mjs';
 //New Device Entry; endpointARN is assigned by server
 export const NOTIFICATION_DEVICE_FIELDS:InputField[] = [
     new InputField({title: 'Device Name', field: 'deviceName', type:InputType.TEXT, validationRegex: new RegExp(/^[a-zA-Z0-9' _.-]{1,100}$/), validationMessage: 'Required, 5-100 chars, letters, numbers, dashes, underscores.' }),
-    new InputField({title: 'Token', field: 'deviceToken', type:InputType.TEXT, validationRegex: new RegExp(/^[a-zA-Z0-9.:_-]{1,255}$/), validationMessage: 'Required, 5-100 chars, letters, numbers, dashes, underscores.' })
+    new InputField({title: 'Token', field: 'deviceToken', type:InputType.TEXT, validationRegex: new RegExp(/^[a-zA-Z0-9.:_-]{1,255}$/), validationMessage: 'Required, 5-100 chars, letters, numbers, dashes, underscores.' }),
+    new InputField({title: 'DeviceOS', field: 'deviceOS', type:InputType.TEXT, validationRegex: new RegExp(/^ANDROID|IOS$/), validationMessage: 'Required, must be one of ANDROID or iOS' })
 ];
 
 //Only fields saved to out database are editable

--- a/1-src/1-api/2-auth/auth-utilities.mts
+++ b/1-src/1-api/2-auth/auth-utilities.mts
@@ -47,11 +47,12 @@ await InitializeJWTSecretKey();
 ******************* */
 export const generateJWT = (userID:number, userRole:RoleEnum):string => {
     //generate JWT as type JWTData
-    if(userID > 0 && userRole as RoleEnum !== undefined)
+    if(userID > 0 && userRole as RoleEnum !== undefined) {
+        type ExpireTimeValue = '2h' | '15m' | '10d';  //jsonwebtoken has strick type format checking; here's a few options for
+        
         // default config generates signature with HS256 - https://www.npmjs.com/package/jsonwebtoken
-        // @ts-ignore
-        return jwtPackage.sign({jwtUserID: userID, jwtUserRole: userRole}, APP_SECRET_KEY, {expiresIn: process.env.JWT_DURATION || '15 minutes'});
-    else {
+        return jwtPackage.sign({jwtUserID: userID, jwtUserRole: userRole}, APP_SECRET_KEY, {expiresIn: (process.env.JWT_DURATION || '15m') as ExpireTimeValue});
+    } else {
         log.error(`JWT Generation Failed: INVALID userID: ${userID} or userRole: ${userRole}`);
         return '';
     }

--- a/1-src/1-api/2-auth/auth-utilities.mts
+++ b/1-src/1-api/2-auth/auth-utilities.mts
@@ -49,6 +49,7 @@ export const generateJWT = (userID:number, userRole:RoleEnum):string => {
     //generate JWT as type JWTData
     if(userID > 0 && userRole as RoleEnum !== undefined)
         // default config generates signature with HS256 - https://www.npmjs.com/package/jsonwebtoken
+        // @ts-ignore
         return jwtPackage.sign({jwtUserID: userID, jwtUserRole: userRole}, APP_SECRET_KEY, {expiresIn: process.env.JWT_DURATION || '15 minutes'});
     else {
         log.error(`JWT Generation Failed: INVALID userID: ${userID} or userRole: ${userRole}`);

--- a/1-src/1-api/8-notification/notification-utilities.mts
+++ b/1-src/1-api/8-notification/notification-utilities.mts
@@ -55,7 +55,7 @@ const publishNotifications = async (endpointARNs:string[], message:string) => {
 export const createEndpoint = async(deviceToken:string, deviceOS:DeviceOSEnum):Promise<string> => {
     try {
         const response:CreatePlatformEndpointCommandOutput = await snsClient.send(new CreatePlatformEndpointCommand({
-            PlatformApplicationArn: deviceOS === DeviceOSEnum.ANDROID ? process.env.FIREBASE_PLATFORM_APPLICATION_ARN : [ENVIRONMENT_TYPE.LOCAL, ENVIRONMENT_TYPE.DEVELOPMENT].includes(getEnvironment()) ? process.env.APNS_DEV_PLATFORM_APPLICATION_ARN : process.env.APNS_DEV_PLATFORM_APPLICATION_ARN,
+            PlatformApplicationArn: deviceOS === DeviceOSEnum.ANDROID ? process.env.FIREBASE_PLATFORM_APPLICATION_ARN : [ENVIRONMENT_TYPE.LOCAL, ENVIRONMENT_TYPE.DEVELOPMENT].includes(getEnvironment()) ? process.env.APNS_DEV_PLATFORM_APPLICATION_ARN : process.env.APNS_PROD_PLATFORM_APPLICATION_ARN,
             Token: deviceToken
         }));
         return response.EndpointArn;

--- a/1-src/1-api/8-notification/notification-utilities.mts
+++ b/1-src/1-api/8-notification/notification-utilities.mts
@@ -8,13 +8,15 @@ import { CircleNotificationType, NotificationType } from './notification-types.m
 import { DB_SELECT_CIRCLE } from '../../2-services/2-database/queries/circle-queries.mjs';
 import { CircleListItem } from '../../0-assets/field-sync/api-type-sync/circle-types.mjs';
 import { DeviceVerificationResponseType, NotificationDeviceSignup } from '../../0-assets/field-sync/api-type-sync/notification-types.mjs';
+import { DeviceOSEnum, ENVIRONMENT_TYPE } from '../../0-assets/field-sync/input-config-sync/inputField.mjs';
+import { getEnvironment } from '../../2-services/10-utilities/utilities.mjs';
 
 const snsClient = new SNSClient({ region: process.env.SNS_REGION });
 
 // SNS headers for Apple
 const SNS_APNS_HEADERS = {
     "AWS.SNS.MOBILE.APNS.PUSH_TYPE":{"DataType":"String","StringValue":"alert"},
-    "AWS.SNS.MOBILE.APNS.PRIORITY":{"DataType":"String","StringValue":"5"}
+    "AWS.SNS.MOBILE.APNS.PRIORITY":{"DataType":"String","StringValue":"10"}
 }
 
 const getIndividualPrayerRequestNotificationBody = (username: string) => `New prayer request from ${username}`;
@@ -50,10 +52,10 @@ const publishNotifications = async (endpointARNs:string[], message:string) => {
     }
 }
 
-export const createEndpoint = async(deviceToken:string):Promise<string> => {
+export const createEndpoint = async(deviceToken:string, deviceOS:DeviceOSEnum):Promise<string> => {
     try {
         const response:CreatePlatformEndpointCommandOutput = await snsClient.send(new CreatePlatformEndpointCommand({
-            PlatformApplicationArn: process.env.PLATFORM_APPLICATION_ARN,
+            PlatformApplicationArn: deviceOS === DeviceOSEnum.ANDROID ? process.env.FIREBASE_PLATFORM_APPLICATION_ARN : [ENVIRONMENT_TYPE.LOCAL, ENVIRONMENT_TYPE.DEVELOPMENT].includes(getEnvironment()) ? process.env.APNS_DEV_PLATFORM_APPLICATION_ARN : process.env.APNS_DEV_PLATFORM_APPLICATION_ARN,
             Token: deviceToken
         }));
         return response.EndpointArn;
@@ -166,6 +168,7 @@ export const saveNotificationDevice = async(userID:number, notificationDevice:No
 
     const nameRegex: RegExp = NOTIFICATION_DEVICE_FIELDS.find((input) => input.field === 'deviceName')?.validationRegex || new RegExp(/.{1,100}/);
     const tokenRegex: RegExp = NOTIFICATION_DEVICE_FIELDS.find((input) => input.field === 'deviceToken')?.validationRegex || new RegExp(/.{1,255}/);
+    const deviceOSRegex: RegExp = NOTIFICATION_DEVICE_FIELDS.find((input) => input.field === 'deviceOS')?.validationRegex || new RegExp(/^ANDROID|IOS$/);
 
     //Configure Defaults & Custom Settings
     if(!deviceName || deviceName.length <= 1) deviceName = `User ${userID} ${String(deviceOS ?? 'Device').toLowerCase()}`;
@@ -175,13 +178,14 @@ export const saveNotificationDevice = async(userID:number, notificationDevice:No
     if(!deviceName || !nameRegex.test(deviceName)) {
         log.warn('Invalid notification device detail for user:', userID, 'Invalid deviceName', deviceName);
         return -1;
-
     } else if(!deviceToken || !tokenRegex.test(deviceToken)) {
         log.warn('Invalid notification device detail for user:', userID, 'Invalid deviceToken', deviceToken);
         return -1;
-
+    } else if (!deviceOS || !deviceOSRegex.test(deviceOS)) {
+        log.warn('Invalid notification device detail for user:', userID, 'Invalid deviceOS', deviceOS);
+        return -1;
     } else {
-        const endpointArn = await createEndpoint(deviceToken);
+        const endpointArn = await createEndpoint(deviceToken, deviceOS);
         await DB_INSERT_NOTIFICATION_DEVICE(userID, deviceName, endpointArn);
 
         const deviceIDPromise = await DB_SELECT_NOTIFICATION_DEVICE_ID({userID, endpointArn});

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "server": "npm run serve",
     "start": "npm run build & npm run open & npm run serve",
     "update": "npm run website && npm run portal && npm run start",
-    "debug": "npm run build & npm run serve"
+    "debug": "npm run build & npm run serve",
+    "clean": "rimraf node_modules/ package-lock.json 0-compiled/"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.417.0",
     "@aws-sdk/client-secrets-manager": "^3.565.0",
     "@aws-sdk/client-sns": "^3.709.0",
-    "@types/dotenv": "^8.2.0",
     "@types/jsonwebtoken": "^9.0.2",
     "argon2": "^0.41.1",
     "axios": "^1.5.0",
@@ -39,7 +39,7 @@
     "metascraper-title": "^5.45.9",
     "mysql2": "3.11.3",
     "path": "^0.12.7",
-    "rimraf": "^3.0.2",
+    "rimraf": "5.0.10",
     "socket.io": "^4.5.4",
     "stack-trace": "^1.0.0-pre1",
     "ts-node": "9.1"


### PR DESCRIPTION
Fix for notifications not working on iOS

- added a separate platform application for APNS on AWS

To be able to tell which platform application a device should be created for, I made DeviceOSEnum a required parameter. This is only required for creating the endpointARN. Once the endpoint is created, AWS SNS figures out which device to send notifications to on its own. 

use the following env variables:

```
# AWS SNS SETTINGS
SNS_REGION = us-east-1
FIREBASE_PLATFORM_APPLICATION_ARN = arn:aws:sns:us-east-1:390212030228:app/GCM/EncouragingPrayer
APNS_PROD_PLATFORM_APPLICATION_ARN = arn:aws:sns:us-east-1:390212030228:app/APNS/EncouragingPrayer-APNS-Prod
APNS_DEV_PLATFORM_APPLICATION_ARN = arn:aws:sns:us-east-1:390212030228:app/APNS/EncouragingPrayer-APNS-Prod
```