### PR TITLE
145 image inconsistencies

### DIFF
--- a/1-src/2-services/10-utilities/image-utilities.mts
+++ b/1-src/2-services/10-utilities/image-utilities.mts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import * as log from './logging/log.mjs';
 import { ENVIRONMENT_TYPE, SUPPORTED_IMAGE_EXTENSION_LIST } from '../../0-assets/field-sync/input-config-sync/inputField.mjs';
 import { ImageTypeEnum } from '../../1-api/api-types.mjs';
-import { getEnvironment, isEnumValue, isURLValid } from './utilities.mjs';
+import { getEnvironment, getSHA256Hash, isEnumValue, isURLValid } from './utilities.mjs';
 import dotenv from 'dotenv';
 dotenv.config(); 
 
@@ -40,8 +40,11 @@ dotenv.config();
   
 export const getImageFileName = ({id, imageType, fileName}:{id:number, imageType:ImageTypeEnum, fileName:string}):string|undefined => {
     const extension = fileName.split('.').pop(); //dot optional
+    const currentTime = new Date().getTime().toString();
+    const fileNameHash = getSHA256Hash(`${imageType.toLowerCase()}_${id}_${currentTime}`);
+    console.log(fileNameHash);
     if(SUPPORTED_IMAGE_EXTENSION_LIST.includes(extension)) 
-        return `${imageType.toLowerCase()}_${id}.${extension}`;
+        return `${imageType.toLowerCase()}_${id}_${fileNameHash}.${extension}`;
     else {
         log.error('Image Upload to AWS S3 with unsupported file type.', extension, fileName, imageType, id);
         return undefined;

--- a/1-src/2-services/10-utilities/image-utilities.mts
+++ b/1-src/2-services/10-utilities/image-utilities.mts
@@ -42,7 +42,6 @@ export const getImageFileName = ({id, imageType, fileName}:{id:number, imageType
     const extension = fileName.split('.').pop(); //dot optional
     const currentTime = new Date().getTime().toString();
     const fileNameHash = getSHA256Hash(`${imageType.toLowerCase()}_${id}_${currentTime}`);
-    console.log(fileNameHash);
     if(SUPPORTED_IMAGE_EXTENSION_LIST.includes(extension)) 
         return `${imageType.toLowerCase()}_${id}_${fileNameHash}.${extension}`;
     else {

--- a/1-src/2-services/10-utilities/utilities.mts
+++ b/1-src/2-services/10-utilities/utilities.mts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { ENVIRONMENT_TYPE } from '../../0-assets/field-sync/input-config-sync/inputField.mjs';
 import { DATABASE_MODEL_SOURCE_ENVIRONMENT_ENUM } from '../2-database/database-types.mjs';
 import dotenv from 'dotenv';
@@ -44,3 +45,5 @@ export const extractRegexMaxLength = (regex:RegExp, findMin?:boolean):number => 
         (findMin ? parseInt(match[1], 10) : parseInt(match[2], 10)) 
         : (findMin ? 0 : Number.MAX_SAFE_INTEGER);
 }
+
+export const getSHA256Hash = (value:string) => createHash('sha256').update(value).digest('hex');


### PR DESCRIPTION
Previously, when a user updated their profile image, the change did not propagate throughout the rest of the app. This is because the file name stays static on the server side (as long as the file extension is the same).

Small refactor to add a utility function to create a SHA256 hash, and to add a discriminator at the end of a filename before uploading it to S3.
