### PR TITLE
147 | Server | S3 Logs & Athena Search

### DIFF
--- a/1-src/0-assets/field-sync/api-type-sync/utility-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/utility-types.mts
@@ -42,6 +42,7 @@ export type LogListItem = {
     timestamp:number; 
     type:LogType; 
     messages:string[]; 
+    messageSearch:string; //Combine string for AWS Athena query
     stackTrace?:string[]; 
     fileKey?:string; 
     duplicateList?:string[]; 

--- a/1-src/0-assets/field-sync/api-type-sync/utility-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/utility-types.mts
@@ -30,7 +30,6 @@ export enum LogLocation {
 }
 
 export enum LogType {
-    ALERT = 'ALERT', 
     ERROR = 'ERROR', 
     WARN = 'WARN', 
     DB = 'DB', 

--- a/1-src/1-api/1-utility/log.mts
+++ b/1-src/1-api/1-utility/log.mts
@@ -148,11 +148,11 @@ export const GET_LogDownloadFile = async(logType:LogType|undefined, request:LogE
     
     //Initiate file stream within log utilities
     if(location === LogLocation.LOCAL)
-        streamLocalLogFile(logType, response);
+        streamLocalLogFile(logType, response, next);
     else if(location === LogLocation.S3)
-        streamS3LogsAsFile(logType, response);
+        streamS3LogsAsFile(logType, response, next);
     else
-        return next(new Exception(404, `Download unavailable for log location: ${location}`));
+        return next(new Exception(404, `Download unavailable for log location: ${location}`, 'Invalid Location'));
 }
 
 

--- a/1-src/1-api/2-auth/auth-types.mts
+++ b/1-src/1-api/2-auth/auth-types.mts
@@ -96,12 +96,17 @@ export interface JwtAdminRequest extends JwtRequest {
 
 };
 
-export interface LogSearchRequest extends JwtAdminRequest {
+export interface LogEntryLocationRequest extends JwtAdminRequest {
+    query: {
+        location?:string
+    }
+};
+
+export interface LogSearchRequest extends LogEntryLocationRequest {
     params:JwtAdminRequest['params'] & {
         type?:string
     },
-    query: {
-        location?:string
+    query:LogEntryLocationRequest['query'] & {
         search?:string,
         cumulativeIndex?:string, //Cumulative entry count; use to estimate start; only works with endTimestamp marker
         startTimestamp?:string,
@@ -111,12 +116,9 @@ export interface LogSearchRequest extends JwtAdminRequest {
     },
 };
 
-export interface LogEntryNewRequest extends JwtAdminRequest {
+export interface LogEntryNewRequest extends LogEntryLocationRequest {
     params:JwtAdminRequest['params'] & {
         type?:string
-    },
-    query: {
-        location?:string
     },
     body: string|string[]
 };

--- a/1-src/1-api/2-auth/auth-types.mts
+++ b/1-src/1-api/2-auth/auth-types.mts
@@ -102,6 +102,12 @@ export interface LogEntryLocationRequest extends JwtAdminRequest {
     }
 };
 
+export interface LogEntryDayRequest extends JwtAdminRequest {
+    query: {
+        timestamp:string
+    }
+};
+
 export interface LogSearchRequest extends LogEntryLocationRequest {
     params:JwtAdminRequest['params'] & {
         type?:string

--- a/1-src/1-api/2-auth/auth-utilities.mts
+++ b/1-src/1-api/2-auth/auth-utilities.mts
@@ -58,7 +58,7 @@ export const generateJWT = (userID:number, userRole:RoleEnum):string => {
     }
 }
 
-export const verifyJWT = (jwt:string):Boolean => {
+export const verifyJWT = (jwt:string):boolean => {
     try {
         jwtPackage.verify(jwt, APP_SECRET_KEY);
         return true;

--- a/1-src/1-api/2-auth/auth-utilities.mts
+++ b/1-src/1-api/2-auth/auth-utilities.mts
@@ -47,10 +47,12 @@ await InitializeJWTSecretKey();
 ******************* */
 export const generateJWT = (userID:number, userRole:RoleEnum):string => {
     //generate JWT as type JWTData
-    if(userID > 0 && userRole as RoleEnum !== undefined)
+    if(userID > 0 && userRole as RoleEnum !== undefined) {
+        type ExpireTimeValue = '2h' | '15m' | '10d';  //jsonwebtoken has strick type format checking; here's a few options for
+        
         // default config generates signature with HS256 - https://www.npmjs.com/package/jsonwebtoken
-        return jwtPackage.sign({jwtUserID: userID, jwtUserRole: userRole}, APP_SECRET_KEY, {expiresIn: process.env.JWT_DURATION || '15 minutes'});
-    else {
+        return jwtPackage.sign({jwtUserID: userID, jwtUserRole: userRole}, APP_SECRET_KEY, {expiresIn: (process.env.JWT_DURATION || '15m') as ExpireTimeValue});
+    } else {
         log.error(`JWT Generation Failed: INVALID userID: ${userID} or userRole: ${userRole}`);
         return '';
     }

--- a/1-src/1-api/4-circle/circle-utilities.mts
+++ b/1-src/1-api/4-circle/circle-utilities.mts
@@ -10,7 +10,7 @@ import { JwtSearchRequest } from '../api-types.mjs';
  **********************************/
 
 //Intelligently clear circle_search_cache base on circle change | [SYNC with searchCircleList]
-export const updateCircleListCache = async(updatedFields:Map<string, any>):Promise<Boolean> => {
+export const updateCircleListCache = async(updatedFields:Map<string, any>):Promise<boolean> => {
     const filterList:CircleSearchRefineEnum[] = [CircleSearchRefineEnum.ALL];
     const valueList:string[] = [];
 

--- a/1-src/2-services/10-utilities/athena.mts
+++ b/1-src/2-services/10-utilities/athena.mts
@@ -58,7 +58,6 @@ export const executeAthenaQuery = async(command:StartQueryExecutionCommand, maxD
         /* Evaluate Result */
         if(startResponse && status === AthenaStatus.SUCCEEDED) {
             const duration:number = new Date().getTime() - startTimestamp;
-            await log.event(`Athena Query Succeeded for ${command.input?.QueryExecutionContext?.Database}`, 'Duration: (ms)', duration);
             return { queryExecutionId:queryExecutionId, success:(status === AthenaStatus.SUCCEEDED), status:status, duration:duration, rows:[] };
 
         } else

--- a/1-src/2-services/10-utilities/athena.mts
+++ b/1-src/2-services/10-utilities/athena.mts
@@ -1,0 +1,214 @@
+import { AthenaClient, StartQueryExecutionCommand, GetQueryExecutionCommand, StartQueryExecutionCommandOutput, GetQueryExecutionCommandOutput, GetQueryResultsOutput, GetQueryResultsCommand } from '@aws-sdk/client-athena';
+import * as log from './logging/log.mjs';
+
+
+/********************************************
+ * ATHENA QUERY HANDLING                    *
+ * Queries need to be polled for completion *
+ ********************************************/
+export enum AthenaStatus { //May be more
+    QUEUED = 'QUEUED',
+    RUNNING = 'RUNNING',
+    SUCCEEDED = 'SUCCEEDED',
+    FAILED = 'FAILED',
+    CANCELLED = 'FAILED',
+    TIMEOUT = 'TIMEOUT' //Assigned here
+}
+
+export interface AthenaQueryResult {
+    queryExecutionId:string;
+    success:boolean;
+    status:AthenaStatus;
+    duration:number; //milliseconds
+    rows:any[];
+}
+
+const athena = new AthenaClient({ region: process.env.ATHENA_REGION });
+
+export const executeAthenaQuery = async(command:StartQueryExecutionCommand, maxDuration:number = 60000):Promise<AthenaQueryResult> => {
+    const startTimestamp = new Date().getTime();
+    let queryExecutionId = 'NO ID ASSIGNED';
+    let status:AthenaStatus = AthenaStatus.QUEUED;
+
+    try {
+        const startResponse:StartQueryExecutionCommandOutput = await athena.send(command);
+        queryExecutionId = startResponse.QueryExecutionId;
+
+        if(!queryExecutionId) {
+            log.error('ATHENA QUERY - FAILED to INITIATE', JSON.stringify(startResponse), JSON.stringify(command));
+            return { queryExecutionId:queryExecutionId, success: false, status: AthenaStatus.FAILED, duration: 0, rows: [] };
+        }
+
+        //Poll for query completion
+        const statusCommand:GetQueryExecutionCommand = new GetQueryExecutionCommand({ QueryExecutionId: queryExecutionId });
+        let statusResponse:GetQueryExecutionCommandOutput;
+        do {
+            statusResponse = await athena.send(statusCommand);  
+            status = AthenaStatus[statusResponse.QueryExecution?.Status?.State ?? AthenaStatus.FAILED];
+
+            if([AthenaStatus.SUCCEEDED, AthenaStatus.FAILED, AthenaStatus.CANCELLED, AthenaStatus.TIMEOUT].includes(status)) {
+                break;
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+        } while(new Date().getTime() < (startTimestamp + maxDuration));
+
+
+        /* Evaluate Result */
+        if(startResponse && status === AthenaStatus.SUCCEEDED) {
+            const duration:number = new Date().getTime() - startTimestamp;
+            await log.event(`Athena Query Succeeded for ${command.input?.QueryExecutionContext?.Database}`, 'Duration: (ms)', duration);
+            return { queryExecutionId:queryExecutionId, success:(status === AthenaStatus.SUCCEEDED), status:status, duration:duration, rows:[] };
+
+        } else
+            throw new Error('Query Completed Unsuccessfully');
+        
+    } catch(error) {
+        const duration:number = new Date().getTime() - startTimestamp;
+        await log.error(`${status} Athena Query - Athena for ${command.input?.QueryExecutionContext?.Database}`, error,
+            'Duration: (ms)', duration, 'Timeout scheduled after: (ms)', maxDuration, 'Query:', command.input?.QueryString);
+        return { queryExecutionId:queryExecutionId, success:false, status:(duration >= maxDuration) ? AthenaStatus.TIMEOUT : status, duration:duration, rows:[] };
+    }
+};
+
+
+/* Query and Retrieve Row Results */
+export type AthenaFieldSchema = Map<string, { type:'string'|'number'|'boolean'|'stringArray'|'numberArray', defaultIndicator:string, defaultApplied:any }>;
+
+export const searchAthenaQuery = async(command:StartQueryExecutionCommand, fieldMap:AthenaFieldSchema = new Map(), maxDuration:number = 60000):Promise<AthenaQueryResult> => {
+    let statusResult:AthenaQueryResult = { queryExecutionId:'', success:false, status:AthenaStatus.QUEUED, duration:0, rows:[] };
+    try {
+        statusResult = await executeAthenaQuery(command, maxDuration);
+
+        if(!statusResult.success) return statusResult;
+
+        const resultCommand = new GetQueryResultsCommand({ QueryExecutionId: statusResult.queryExecutionId });
+        const queryResults = await athena.send(resultCommand);
+        const rowResults = queryResults.ResultSet?.['ResultRows'] || [];
+
+        if(rowResults.length <= 1) return statusResult;
+
+        //If table sells are null, they are removed from result array and can cause misalignment in matching header fields to data
+        if(!fieldMap.size && rowResults.some((row: { Data:string[] }) => row.Data.length !== fields.length))
+            log.warn(`Athena Search has missing data and no parsing schema defined - Athena for ${command.input?.QueryExecutionContext?.Database}`, 'Query:', command.input?.QueryString);
+
+        /* Parse Result Rows */
+        const fields:string[] = rowResults[0].Data; //First row are fieldNames/Headers
+        const rows = rowResults.slice(1).map((row: { Data:string[] }, rowIndex) => {
+            const obj: Record<string, any> = {};
+            row.Data.filter((v,i) => !fieldMap.size || fieldMap.has(fields[i])).forEach((value, index) => {
+                const column:string = fields[index];
+                obj[column] =
+                    (value === fieldMap.get(column)?.defaultIndicator?.replace(/(['"]|ARRAY)/g, '')) //SQL requires default format: "ARRAY['EMPTY']" to populate: '[EMPTY]'
+                        ? fieldMap.get(column).defaultApplied
+                        
+                    : (value === null || value === undefined || value === 'null' || value === 'undefined') ? undefined
+                    
+                    /* Parse via fieldMap.type */
+                    : (fieldMap.get(column)?.type === 'string')
+                        ? String(value)
+                    : (fieldMap.get(column)?.type === 'number')
+                        ? (isNaN(Number(value)) ? undefined : Number(value))
+                    : (fieldMap.get(column)?.type === 'boolean')
+                        ? (value === 'true' || value === '1')
+                    : (fieldMap.get(column)?.type === 'stringArray')
+                        ? parseStringArray(value)
+                    : (fieldMap.get(column)?.type === 'numberArray')
+                        ? parseStringArray(value).map(v => (isNaN(Number(v)) ? undefined : Number(v)))
+                    : value;
+            });
+            return obj;
+        });
+
+        return {...statusResult, rows};
+
+    } catch(error) {
+        await log.error(`Failed Fetching Athena Query Results - Athena for ${command.input?.QueryExecutionContext?.Database}`, error, 'Query:', command.input?.QueryString);
+        return {...statusResult, status: AthenaStatus.FAILED};
+    }
+}
+
+
+
+//Partitioning S3 into Athena Table updates the folders (not data) used in query
+const MAX_PARTITION_TIMEOUT_MS = 30000; //30sec ~ Estimate 0.00015s/partition ~ For S3 Logs: 200k Days if daily or 8k Days if hourly
+export const updateAthenaPartitions = async(databaseName:string, tableName:string, saveBucketLocation:string): Promise<boolean> => {
+    if(!databaseName || databaseName.length < 3 || !tableName || tableName.length < 3) {
+        log.alert('updateAthenaPartitions - Invalid Athena database names: ', databaseName, tableName);
+        return false;
+    }
+
+    const params = {
+        QueryString: `MSCK REPAIR TABLE ${tableName};`,
+        QueryExecutionContext: {
+            Database: databaseName,
+        },
+        ResultConfiguration: { OutputLocation: saveBucketLocation }
+    };
+
+    const response:AthenaQueryResult = await executeAthenaQuery(new StartQueryExecutionCommand(params), MAX_PARTITION_TIMEOUT_MS);
+    if(response.success)
+        log.event(`Athena ${databaseName}.${tableName} partitioning completed.`, 'Duration: (ms)', response.duration);
+    else
+        log.error(`${response.status} - partitioning Athena ${databaseName}.${tableName}.`);
+
+    return response.success;
+}
+   
+
+
+
+/* UTILITIES */
+const parseStringArray = (text:string):string[] => {
+    if(!text || typeof text !== 'string') return [];
+    text = text.trim();
+
+    //Optionally: remove end brackets
+    if(text.startsWith('[') && text.endsWith(']'))
+        text = text.slice(1, -1);
+
+    //Preserve groupings inside JSON stringified
+    const result: string[] = [];
+    let buffer = '';
+    let curlyBrackets = 0;
+    let squareBrackets = 0;
+    let roundBrackets = 0;
+    let doubleQuoteCount = 0;
+    let singleQuoteCount = 0;
+
+    for(const char of text) {
+        // Track brackets
+        if(char === '{') curlyBrackets++;
+        if(char === '}') curlyBrackets--;
+        if(char === '[') squareBrackets++;
+        if(char === ']') squareBrackets--;
+        if(char === '(') roundBrackets++;
+        if(char === ')') roundBrackets--;
+
+        // Track quotes (toggle by incrementing/decrementing)
+        if(char === '"') doubleQuoteCount += (doubleQuoteCount % 2 === 0 ? 1 : -1);
+        if(char === "'") singleQuoteCount += (singleQuoteCount % 2 === 0 ? 1 : -1);
+
+        // Handle splitting at commas only if not inside any structure
+        if(
+            char === ',' &&
+            curlyBrackets === 0 &&
+            squareBrackets === 0 &&
+            roundBrackets === 0 &&
+            doubleQuoteCount === 0 &&
+            singleQuoteCount === 0
+        ) {
+            result.push(buffer.trim());
+            buffer = '';
+        } else {
+            buffer += char;
+        }
+    }
+
+    if(buffer.length > 0) {
+        result.push(buffer.trim()); // Add last part
+    }
+
+    return result;
+}

--- a/1-src/2-services/10-utilities/logging/log-local-utilities.mts
+++ b/1-src/2-services/10-utilities/logging/log-local-utilities.mts
@@ -304,7 +304,6 @@ const calculateLogSize = async (type:LogType):Promise<number|undefined> => { //B
 
 const estimateLine = (type:LogType, bytes:number):number => { 
     switch(type) {
-        case LogType.ALERT:
         case LogType.ERROR:
             return Math.floor(bytes / 830);
         case LogType.DB:
@@ -318,7 +317,6 @@ const estimateLine = (type:LogType, bytes:number):number => {
 
 const estimateBytes = (type:LogType, entries:number):number => { 
     switch(type) {
-        case LogType.ALERT:
         case LogType.ERROR:
             return entries * 830;
         case LogType.DB:

--- a/1-src/2-services/10-utilities/logging/log-local-utilities.mts
+++ b/1-src/2-services/10-utilities/logging/log-local-utilities.mts
@@ -1,7 +1,7 @@
 import fs, { promises as fsPromises } from 'fs';
 import { NextFunction, Response } from 'express';
 import readline from 'readline';
-import { LOG_DIRECTORY, getLogFilePath, LOG_MAX_SIZE_BYTES, LOG_ROLLOVER_SIZE_BYTES, LOG_ESTIMATE_CONFIDENCE, SAVE_LOGS_LOCALLY } from './log-types.mjs';
+import { LOG_DIRECTORY, getLogFilePath, LOG_MAX_SIZE_BYTES, LOG_ROLLOVER_SIZE_BYTES, LOG_ESTIMATE_CONFIDENCE, SAVE_LOGS_LOCALLY, LOG_SEARCH_DEFAULT_MAX_ENTRIES } from './log-types.mjs';
 import { LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
 import LOG_ENTRY, { logDateRegex } from './logEntryModel.mjs';
 import { getEnvironment } from '../utilities.mjs';
@@ -99,7 +99,7 @@ export const resetLogFile = async(type:LogType, validate:boolean = false):Promis
                     .sort((a,b) => a.getTimestamp() - b.getTimestamp())
                     .map(entry => entry.toString()).join('\n') + '\n', 'utf-8');
 
-                resolve(logEntriesKeeping.slice(-1 * 500).reverse());
+                resolve(logEntriesKeeping.slice(-1 * LOG_SEARCH_DEFAULT_MAX_ENTRIES).reverse());
             });
 
             readInterface.on('error', async(error) => {
@@ -174,7 +174,7 @@ export const readLogFile = async (type:LogType, maxEntries:number|undefined = un
                 if(failedValidation > 0)
                     await saveLogLocally(type, `Local ReadLogFile skipped ${failedValidation} entries with failed validations.`);
 
-                resolve(logEntries.slice(-1 * (maxEntries ?? 500)).reverse());
+                resolve(logEntries.slice(-1 * (maxEntries ?? LOG_SEARCH_DEFAULT_MAX_ENTRIES)).reverse());
             });
 
             readInterface.on('error', async(error) => {

--- a/1-src/2-services/10-utilities/logging/log-local-utilities.mts
+++ b/1-src/2-services/10-utilities/logging/log-local-utilities.mts
@@ -268,6 +268,7 @@ export const streamLocalLogFile = async(logType:LogType, response:Response, next
 
         fileStream.on('error', async(error) => {
             await saveLogLocally(logType, `Streaming ${logType} log from local txt file error: `, String(error));
+            next(new Exception(500, `Error streaming local log file: ${getLogFilePath(logType)}`, 'Failed Stream'));
         });
         return response;
     } catch(error) { //Not returning Exception, b/c fileStream is ongoing

--- a/1-src/2-services/10-utilities/logging/log-s3-athena-search.mts
+++ b/1-src/2-services/10-utilities/logging/log-s3-athena-search.mts
@@ -1,10 +1,10 @@
-import {  StartQueryExecutionCommand } from '@aws-sdk/client-athena';
+import { StartQueryExecutionCommand } from '@aws-sdk/client-athena';
 import { AthenaQueryResult, searchAthenaQuery, updateAthenaPartitions } from '../athena.mjs';
-import * as log from './log.mjs';
-import LOG_ENTRY from './logEntryModel.mjs';
-import { LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
 import { getEnvironment } from '../utilities.mjs';
 import { ENVIRONMENT_TYPE } from '../../../0-assets/field-sync/input-config-sync/inputField.mjs';
+import LOG_ENTRY from './logEntryModel.mjs';
+import { LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
+import * as log from './log.mjs';
 
 /*
     Athena Table to Query S3 Logs
@@ -91,7 +91,7 @@ export const athenaSearchS3Logs = async(type:LogType, searchTerm:string, startTi
             + `AND logs_dev.timestamp >= ${startDate.getTime()} AND logs_dev.timestamp <= ${endDate.getTime()} `
         +') '
 
-        //Apply 'undefined' as column placeholder | ('timestamp' is a SQL keyword)
+        //Apply placeholders for empty columns, otherwise omitted in results array | ('timestamp' is a SQL keyword)
         + `SELECT ${Array.from(LOG_ENTRY.JSONFieldDetails.entries()).filter(([key]) => key !== 'timestamp').map(([key, value]:[string, { defaultIndicator:string }]) => `COALESCE(${key}, ${value.defaultIndicator}) AS ${key}`).join(', ')}, `
             + 'ts AS timestamp, '
             + '(fullMatchScore + partialMatchScore + wordMatchScore) AS score '

--- a/1-src/2-services/10-utilities/logging/log-s3-athena-search.mts
+++ b/1-src/2-services/10-utilities/logging/log-s3-athena-search.mts
@@ -1,0 +1,124 @@
+import {  StartQueryExecutionCommand } from '@aws-sdk/client-athena';
+import { AthenaQueryResult, searchAthenaQuery, updateAthenaPartitions } from '../athena.mjs';
+import * as log from './log.mjs';
+import LOG_ENTRY from './logEntryModel.mjs';
+import { LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
+import { getEnvironment } from '../utilities.mjs';
+import { ENVIRONMENT_TYPE } from '../../../0-assets/field-sync/input-config-sync/inputField.mjs';
+
+/*
+    Athena Table to Query S3 Logs
+        - Table must be created and saved in AWS Athena
+        - Partitions come from fileKey format: type=ERROR/year=2025/month=02/day=06/hour=02
+        - Partitions filter scope and allow query to run in parallel (Athena does this automatically)
+        - New Partitions must be synced with query: MSCK REPAIR TABLE `ATHENA_LOGS_DEV`.`LOGS_DEV`;
+
+    Table Created: 2/12/2025
+    CREATE EXTERNAL TABLE IF NOT EXISTS `ATHENA_LOGS_DEV`.`LOGS_DEV` (
+        `timestamp` bigint, `messageSearch` string, `filekey` string, 
+        `messages` array<string>, `stackTrace` array<string>, `duplicateList` array<string>
+    ) PARTITIONED BY (`type` string, `year` int, `month` int, `day` int)
+    ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe' 
+    WITH SERDEPROPERTIES ('ignore.malformed.json' = 'FALSE', 'dots.in.keys' = 'FALSE', 'case.insensitive' = 'TRUE', 'mapping' = 'TRUE') 
+    STORED AS 
+        INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' 
+        OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat' 
+    LOCATION 's3://pew35-logs-dev/' 
+    TBLPROPERTIES ('classification' = 'json');
+*/
+
+
+/**************************
+* AWS ATHENA QUERY SEARCH *
+***************************/
+//NOTE: Parsing Athena Search Results are not perfect and should not be re-uploaded 
+const MAX_QUERY_TIMEOUT_MS = 15000; //15 seconds
+let lastPartitionUpdateTimestamp:number = 0;
+export const athenaSearchS3Logs = async(type:LogType, searchTerm:string, startTimestamp?:number, endTimestamp?:number, maxEntries:number = 1000, mergeDuplicates:boolean = false):Promise<LOG_ENTRY[]> => {
+    const endDate = new Date(endTimestamp); //Default to today
+    const startDate = new Date(startTimestamp ?? (endDate.getTime() - (7 * 24 * 60 * 60 * 1000))); //7 days
+
+    if(isNaN(startDate.getTime()) || isNaN(endDate.getTime()) || endDate.getTime() < startDate.getTime()) {
+        log.warn('athenaSearchS3Logs called with invalid dates: (start/timestamp/end/timestamp)', startDate, startTimestamp, endDate, endTimestamp);
+        return [];
+    }
+
+    let logList:LOG_ENTRY[] = [];
+    //Only update Partitions on first search of session
+    if(getEnvironment() !== ENVIRONMENT_TYPE.LOCAL && new Date().getTime() > (lastPartitionUpdateTimestamp + (12 * 60 * 60 * 1000))) { //12h, current log partitions are daily
+        if(await updateAthenaPartitions(process.env.LOG_ATHENA_DATABASE, process.env.LOG_ATHENA_TABLE, `s3://${process.env.LOG_BUCKET_NAME}/athena`) === false) //Still attempt search on failure
+            logList.push(new LOG_ENTRY(LogType.ERROR, ['***WARNING - Athena partitioning failed and may affect search results***']));
+    }
+
+    const query = 
+        'WITH ranked AS ( '
+        + `SELECT ${Array.from(LOG_ENTRY.JSONFieldDetails.entries()).filter(([key]) => key !== 'timestamp').map((([key]) => key)).join(', ')}, `
+            + 'logs_dev.timestamp AS ts, '
+            
+            /* +18 points for every whole string match surrounded by word boundaries or symbols */
+            + `CASE 
+                WHEN REGEXP_LIKE(LOWER(messageSearch), '(^|[\\s\\-\\_\\=\\+\\"\\,|\\[\\]\\{\\}<>])${searchTerm.toLowerCase()}($|[\\s\\-\\_\\=\\+\\"\\,|\\[\\]\\{\\}<>])') 
+                    THEN ${18}
+                ELSE 0 
+                END AS fullMatchScore, `
+
+            /* +5 points for every whole string match as a substring | Max 17x points */
+            + ` LEAST(${17}, 
+                    (LENGTH(messageSearch) - LENGTH(REPLACE(LOWER(messageSearch), '${searchTerm.toLowerCase()}', ''))) 
+                        / LENGTH('${searchTerm}') * ${5}
+                ) AS partialMatchScore, `
+
+            /* +1 points for individual word matches as a substring | Max 4x points */
+            //Approach: First removes all occurrences of searchTerm in messageSearch. The difference in lengths gives the total length of characters removed; finally dividing by searchTerm length gets an occurrence.
+            + `LEAST(${4}, (
+                    ${searchTerm.split(' ').filter(s => s.trim().length > 0).map(word =>
+                        `  (LENGTH(messageSearch) - LENGTH(REPLACE(LOWER(messageSearch), '${word.trim().toLowerCase()}', ''))) 
+                            / LENGTH('${word.trim()}') `
+                    ).join(' + ')}
+                )) AS wordMatchScore `
+
+        + `FROM ${process.env.LOG_ATHENA_DATABASE}.${process.env.LOG_ATHENA_TABLE} `
+
+        /* Filter via partitions defined in S3 key | (Athena will query in parallel) */
+        + `WHERE logs_dev.type = '${type}' `
+            + `AND logs_dev.year >= ${startDate.getFullYear()} AND logs_dev.year <= ${endDate.getFullYear()} `  //year is always sequential
+            + `${(startDate.getMonth() <= endDate.getMonth() && startDate.getFullYear() === endDate.getFullYear()) //Months within same year
+                ? `AND logs_dev.month >= ${startDate.getMonth() + 1} AND logs_dev.month <= ${endDate.getMonth() + 1} ` : ''}`
+
+            + `${(startDate.getDate() <= endDate.getDate() && startDate.getMonth() === endDate.getMonth() && startDate.getFullYear() === endDate.getFullYear()) //Days within same month
+                ? `AND logs_dev.day >= ${startDate.getDate()} AND logs_dev.day <= ${endDate.getDate()} ` : ''}`
+
+            + `AND logs_dev.timestamp >= ${startDate.getTime()} AND logs_dev.timestamp <= ${endDate.getTime()} `
+        +') '
+
+        //Apply 'undefined' as column placeholder | ('timestamp' is a SQL keyword)
+        + `SELECT ${Array.from(LOG_ENTRY.JSONFieldDetails.entries()).filter(([key]) => key !== 'timestamp').map(([key, value]:[string, { defaultIndicator:string }]) => `COALESCE(${key}, ${value.defaultIndicator}) AS ${key}`).join(', ')}, `
+            + 'ts AS timestamp, '
+            + '(fullMatchScore + partialMatchScore + wordMatchScore) AS score '
+            + 'FROM ranked '
+            + 'WHERE (fullMatchScore + partialMatchScore + wordMatchScore) > 0 '
+            + 'ORDER BY score DESC, ts DESC '
+            + `LIMIT ${maxEntries};`;
+
+
+    const queryExecutionCommand = new StartQueryExecutionCommand({
+        QueryString: query,
+        QueryExecutionContext: { Database: process.env.LOG_ATHENA_DATABASE },
+        ResultConfiguration: { OutputLocation: `s3://${process.env.LOG_BUCKET_NAME}/athena` }
+    });
+
+    const response:AthenaQueryResult = await searchAthenaQuery(queryExecutionCommand, LOG_ENTRY.JSONFieldDetails, MAX_QUERY_TIMEOUT_MS);
+
+    logList.push(...
+        response.rows.map((row:{string:string}) => 
+            LOG_ENTRY.constructFromJSON(row)
+        ));
+
+    //Remove any that failed to parse
+    logList = logList.filter((entry:LOG_ENTRY) => entry && entry.validateCheck());
+    if(logList.length < response.rows.length)
+        log.warn(`ATHENA SEARCH - failed to parse ${response.rows.length - logList.length} rows of ${response.rows.length} log entries queried.`, type, searchTerm, startDate.getTime(), endDate.getTime(), query);
+
+    //Optionally Combine Similar Duplicate Entires
+    return (mergeDuplicates) ? LOG_ENTRY.mergeDuplicates(logList) : logList;
+}

--- a/1-src/2-services/10-utilities/logging/log-s3-athena-search.mts
+++ b/1-src/2-services/10-utilities/logging/log-s3-athena-search.mts
@@ -5,6 +5,7 @@ import { ENVIRONMENT_TYPE } from '../../../0-assets/field-sync/input-config-sync
 import LOG_ENTRY from './logEntryModel.mjs';
 import { LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
 import * as log from './log.mjs';
+import { LOG_SEARCH_DEFAULT_TIMESPAN } from './log-types.mjs';
 
 /*
     Athena Table to Query S3 Logs
@@ -36,7 +37,7 @@ const MAX_QUERY_TIMEOUT_MS = 15000; //15 seconds
 let lastPartitionUpdateTimestamp:number = 0;
 export const athenaSearchS3Logs = async(type:LogType, searchTerm:string, startTimestamp?:number, endTimestamp?:number, maxEntries:number = 1000, mergeDuplicates:boolean = false):Promise<LOG_ENTRY[]> => {
     const endDate = new Date(endTimestamp); //Default to today
-    const startDate = new Date(startTimestamp ?? (endDate.getTime() - (7 * 24 * 60 * 60 * 1000))); //7 days
+    const startDate = new Date(startTimestamp ?? (endDate.getTime() - LOG_SEARCH_DEFAULT_TIMESPAN));
 
     if(isNaN(startDate.getTime()) || isNaN(endDate.getTime()) || endDate.getTime() < startDate.getTime()) {
         log.warn('athenaSearchS3Logs called with invalid dates: (start/timestamp/end/timestamp)', startDate, startTimestamp, endDate, endTimestamp);

--- a/1-src/2-services/10-utilities/logging/log-s3-athena-search.mts
+++ b/1-src/2-services/10-utilities/logging/log-s3-athena-search.mts
@@ -100,7 +100,6 @@ export const athenaSearchS3Logs = async(type:LogType, searchTerm:string, startTi
             + 'ORDER BY score DESC, ts DESC '
             + `LIMIT ${maxEntries};`;
 
-
     const queryExecutionCommand = new StartQueryExecutionCommand({
         QueryString: query,
         QueryExecutionContext: { Database: process.env.LOG_ATHENA_DATABASE },

--- a/1-src/2-services/10-utilities/logging/log-s3-utilities.mts
+++ b/1-src/2-services/10-utilities/logging/log-s3-utilities.mts
@@ -118,7 +118,7 @@ export const fetchS3LogsByDateRange = async(type:LogType, startTimestamp?:number
     if(promiseQueue.length > 0 && logList.flat().length < maxEntries) {
         logList.push(...await Promise.all(promiseQueue)); //Process remaining days
     }
-console.log('DONE', logList.length, promiseQueue.length);
+
     return logList.flat().slice(0, maxEntries);
 }
   

--- a/1-src/2-services/10-utilities/logging/log-s3-utilities.mts
+++ b/1-src/2-services/10-utilities/logging/log-s3-utilities.mts
@@ -1,0 +1,256 @@
+import { Response } from 'express';
+import { Readable } from 'stream';
+import { DeleteObjectCommand, GetObjectCommand, ListObjectsV2Command, ListObjectsV2CommandOutput, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import LOG_ENTRY from './logEntryModel.mjs';
+import { LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
+import { getEnvironment } from '../utilities.mjs';
+import { ENVIRONMENT_TYPE } from '../../../0-assets/field-sync/input-config-sync/inputField.mjs';
+import { writeLogFile } from './log-local-utilities.mjs';
+import dotenv from 'dotenv';
+dotenv.config(); 
+/* DO NOT IMPORT [ log from '/10-utilities/logging/log.mjs' ] to AVOID INFINITE LOOP */
+
+
+/* Global Instance for S3 Log Management */
+//Initialization if fine locally; but calling s3LogClient.send(command) will fail with authentication
+const s3LogClient = new S3Client({ region: process.env.LOG_BUCKET_REGION });
+
+/* All S3 logging errors will attempt to be recorded locally */
+const saveLogLocally = async(type:LogType, ...messages:string[]):Promise<boolean> =>
+    writeLogFile(
+        new LOG_ENTRY(type, ['AWS S3 LOG UTILITY ERROR', ...messages]),
+        false //Don't evaluateLogSize
+    );
+
+
+/*************************
+ * S3 LOG FETCH HANDLING *
+ *************************/
+export const fetchS3LogEntry = async(key:string):Promise<LOG_ENTRY | undefined> => {
+    try {
+        const command = new GetObjectCommand({
+            Bucket: process.env.LOG_BUCKET_NAME,
+            Key: key,
+        });
+
+        const response = await s3LogClient.send(command);
+        const bodyString:string = await response.Body.transformToString();
+
+        const entry:LOG_ENTRY = LOG_ENTRY.constructFromJSON(JSON.parse(bodyString));
+        entry.fileKey = key;
+        return entry;
+
+    } catch(error) {
+        await saveLogLocally(LogType.ERROR, 'Failed - AWS S3 Log Fetch', key, error);
+        return undefined;
+    }
+}
+
+/* Fetch all Logs for a given day */
+//Populated only from S3 Key (1024 characters), must use individual fetch to get full message list from body
+export const fetchS3LogsByDay = async(type:LogType, date:Date = new Date(), maxEntries:number = 500):Promise<LOG_ENTRY[]> => {
+    try {
+        const params = {
+            Bucket: process.env.LOG_BUCKET_NAME,
+            Prefix: LOG_ENTRY.createDayS3KeyPrefix(type, date),
+        };
+        const command:ListObjectsV2Command = new ListObjectsV2Command(params);
+        const response:ListObjectsV2CommandOutput = await s3LogClient.send(command);
+
+        if(!response.Contents || !Array.isArray(response.Contents) || response.Contents.length === 0)
+            throw new Error('INVALID - response contents');
+
+        let missingKeys:number = 0;
+        let failedValidation:number = 0;
+        const logEntries:LOG_ENTRY[] = [];
+        for(const obj of Array.from(response.Contents).reverse().slice(0, maxEntries)) { //keys are timestamped and should be sorted oldest -> latest
+            if(!obj.Key || obj.Key.length < 10) {
+                missingKeys++;
+                continue;
+            }
+
+            const entry:LOG_ENTRY|undefined = LOG_ENTRY.constructFromS3Key(obj.Key);
+            if(entry && entry.validateCheck())
+                logEntries.push(entry);
+            else
+                failedValidation++;
+        }
+
+        if((missingKeys + failedValidation) > 0)
+            await saveLogLocally(type, `Local fetchS3LogsByDay skipped ${missingKeys} entries of ${response.Contents.length} with missing keys and ${failedValidation} entries with failed validations.`);
+
+        return logEntries;
+    } catch(error) {
+        await saveLogLocally(type, 'FAILED - fetchS3LogsByDay', error);
+        return [];
+    }
+}
+
+export const fetchS3LogsByDateRange = async(type:LogType, startDate:Date, endDate:Date = new Date(), maxEntries:number = 500):Promise<LOG_ENTRY[]> => {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    end.setHours(0, 0, 0, 0);
+
+    const promiseList:Promise<LOG_ENTRY[]>[] = [];
+    while(start <= end) {
+        promiseList.push(fetchS3LogsByDay(type, end, maxEntries)); //maintains order end -> start
+        end.setDate(end.getDate() - 1); //endDate -> startDate
+    }
+
+    const logList:LOG_ENTRY[][] = await Promise.all(promiseList);
+    return logList.flat().slice(maxEntries); //latest
+}
+
+
+//Stream recent entries as a downloadable file
+export const streamS3LogsAsFile = async(logType:LogType, response:Response):Promise<Response> => {
+    try {
+        writeLogFile(
+            new LOG_ENTRY(LogType.EVENT, ['Downloading last 10 days of S3 logs as a file: ', logType]),
+            false //Don't evaluateLogSize
+        );
+
+        const startTime = Date.now() - 10 * 24 * 60 * 60 * 1000; //10 days
+        const logs = await fetchS3LogsByDateRange(logType, new Date(startTime), new Date(), 1000);
+            
+        // Convert logs to a stream and send it as response
+        const logStream = Readable.from(logs.map(log => JSON.stringify(log) + '\n'));
+        logStream.pipe(response);
+
+        logStream.on('error', async(error) => {
+            await saveLogLocally(logType, `Streaming ${logType} log from S3 as txt file error: `, String(error));
+        });
+        return response;
+    } catch(error) { //Not returning Exception, b/c fileStream is ongoing
+        await saveLogLocally(logType, `Error while attempting to stream ${logType} log from S3 as txt file: `, String(error));
+    }
+};
+
+
+/**************************
+ * S3 LOG UPLOAD HANDLING *
+ **************************/
+export const uploadS3LogEntry = async(entry:LOG_ENTRY):Promise<boolean> => {
+    const command = new PutObjectCommand({
+        Bucket: process.env.LOG_BUCKET_NAME,
+        Key: entry.getS3Key(),
+        Body: JSON.stringify(entry.toJSON()),
+        ContentType: 'text',
+    });
+
+    try {
+        await s3LogClient.send(command);
+        return true;
+    } catch(error) {
+        await saveLogLocally(entry.type, 'Failed - AWS S3 Log Upload', entry.getS3Key(), error);
+        return false;
+    }
+}
+
+/* Batch Upload | Throttle Connections */
+const MAX_CONNECTIONS:number = (getEnvironment() === ENVIRONMENT_TYPE.LOCAL) ? 10 : 50;
+export const uploadS3LogBatch = async (entries: LOG_ENTRY[]): Promise<boolean> => {
+    const queue:Promise<boolean>[] = [];
+    for(const entry of entries) {
+        const task:Promise<boolean> = uploadS3LogEntry(entry); //Handles Local or AWS approach
+        queue.push(task);
+
+        if(queue.length >= MAX_CONNECTIONS) {
+            await Promise.race(queue);
+            for (let i = queue.length - 1; i >= 0; i--) {
+                if (queue[i].catch(() => {}) === Promise.resolve()) {
+                    queue.splice(i, 1);
+                }
+            }
+        }
+    }
+
+    const results:boolean[] = await Promise.all(queue);
+    if (results.every((result) => result)) { //All succeeded
+        await saveLogLocally(LogType.EVENT, `Success - AWS S3 batch upload ${results.length}`);
+        return true;
+    } else { //Any Failed
+        await saveLogLocally(LogType.ERROR, `Failed - AWS S3 batch upload ${results.length}`)
+        return false;
+    }
+}
+
+
+/**************************
+ * S3 LOG DELETE HANDLING *
+ **************************/
+export const deleteS3Log = async(key:string):Promise<boolean> => {
+    try {
+        const command = new DeleteObjectCommand({
+            Bucket: process.env.LOG_BUCKET_NAME,
+            Key: key,
+        });
+
+        await s3LogClient.send(command);
+        await saveLogLocally(LogType.EVENT, 'Successful - AWS S3 Log Deleted', key);
+        return true;
+    } catch(error) {
+        await saveLogLocally(LogType.ERROR, 'Failed - AWS S3 Log Deleted', key, error);
+        return false;
+    }
+}
+
+export const deleteS3LogsByDay = async(type:LogType, date:Date = new Date()): Promise<boolean> => {
+    try {
+        const params = {
+         Bucket: process.env.LOG_BUCKET_NAME,
+         Prefix: LOG_ENTRY.createDayS3KeyPrefix(type, date),
+     };
+
+     const command = new ListObjectsV2Command(params);
+     const response:ListObjectsV2CommandOutput = await s3LogClient.send(command);
+
+     if(!response.Contents || !Array.isArray(response.Contents) || response.Contents.length === 0)
+         throw new Error('INVALID - response contents');
+
+     let missingKeys:number = 0;
+     
+     const deletePromises = response.Contents.map((obj) => {
+         if(!obj.Key || obj.Key.length < 10) {
+             missingKeys++;
+             Promise.resolve(true);
+         }
+
+         return deleteS3Log(obj.Key);
+     });
+
+     const results = await Promise.all(deletePromises);
+     const deletionsFailed:number = results.reduce((count, result) => (result === false) ? count++ : count, 0);
+
+     if((missingKeys + deletionsFailed) > 0)
+        await saveLogLocally(LogType.WARN, `AWS deleteS3LogsByDay skipped ${missingKeys} entries of ${results.length} with missing keys and ${deletionsFailed} deletions failed.`);
+
+     return (deletionsFailed === 0);
+ } catch(error) {
+     await saveLogLocally(LogType.ERROR, 'FAILED - deleteS3LogsByDay', type, date.toDateString(), error);
+     return false;
+ }
+}
+
+export const deleteS3LogsByDateRange = async(type:LogType, startDate:Date, endDate:Date): Promise<boolean> => {
+    try {
+        const start:Date = new Date(startDate);
+        const end:Date = new Date(endDate);
+        end.setHours(0, 0, 0, 0);
+
+        const deletePromises: Promise<boolean>[] = [];
+
+        //Generate delete operations for each day in the range
+        while(start <= end) {
+            const dateCopy = new Date(start); //Avoid mutation
+            deletePromises.push(deleteS3LogsByDay(type, dateCopy));
+            start.setDate(start.getDate() + 1); // Increment day
+        }
+
+        const results = await Promise.all(deletePromises);
+        return results.every((result) => result === true);
+    } catch(error) {
+        await saveLogLocally(LogType.ERROR, `Failed - Delete logs within date range ${startDate.toISOString()} to ${endDate.toISOString()}:`, error);
+        return false;
+    }
+}

--- a/1-src/2-services/10-utilities/logging/log-s3-utilities.mts
+++ b/1-src/2-services/10-utilities/logging/log-s3-utilities.mts
@@ -98,7 +98,7 @@ export const fetchS3LogsByDateRange = async(type:LogType, startDate:Date, endDat
     }
 
     const logList:LOG_ENTRY[][] = await Promise.all(promiseList);
-    return logList.flat().slice(maxEntries); //latest
+    return logList.flat().slice(0, maxEntries); //latest
 }
 
 
@@ -149,7 +149,7 @@ export const uploadS3LogEntry = async(entry:LOG_ENTRY):Promise<boolean> => {
 
 /* Batch Upload | Throttle Connections */
 const MAX_CONNECTIONS:number = (getEnvironment() === ENVIRONMENT_TYPE.LOCAL) ? 10 : 50;
-export const uploadS3LogBatch = async (entries: LOG_ENTRY[]): Promise<boolean> => {
+export const uploadS3LogBatch = async (entries:LOG_ENTRY[]): Promise<boolean> => {
     const queue:Promise<boolean>[] = [];
     for(const entry of entries) {
         const task:Promise<boolean> = uploadS3LogEntry(entry); //Handles Local or AWS approach
@@ -157,8 +157,8 @@ export const uploadS3LogBatch = async (entries: LOG_ENTRY[]): Promise<boolean> =
 
         if(queue.length >= MAX_CONNECTIONS) {
             await Promise.race(queue);
-            for (let i = queue.length - 1; i >= 0; i--) {
-                if (queue[i].catch(() => {}) === Promise.resolve()) {
+            for(let i = queue.length - 1; i >= 0; i--) {
+                if(queue[i].catch(() => {}) === Promise.resolve()) {
                     queue.splice(i, 1);
                 }
             }

--- a/1-src/2-services/10-utilities/logging/log-types.mts
+++ b/1-src/2-services/10-utilities/logging/log-types.mts
@@ -23,6 +23,8 @@ export const setSaveAuthLogs = (saveAuthLogs:boolean):void => { SAVE_AUTH_LOGS =
 export let SAVE_EVENT_LOGS = (process.env.SAVE_EVENT_LOGS !== undefined) ? (process.env.SAVE_EVENT_LOGS === 'true') : true;
 export const setSaveEventLogs = (saveEventLogs:boolean):void => { SAVE_LOGS_LOCALLY = saveEventLogs; }
 
+/* S3 LOGGING Controls */
+export const MAX_PARALLEL_CONNECTIONS:number = (getEnvironment() === ENVIRONMENT_TYPE.LOCAL) ? 10 : 30;
 
 
 /* LOCAL LOGGING FILES */

--- a/1-src/2-services/10-utilities/logging/log-types.mts
+++ b/1-src/2-services/10-utilities/logging/log-types.mts
@@ -7,6 +7,11 @@ import { getEnvironment } from '../utilities.mjs';
 
 
 /* LOGGING CONTROLS */
+export const LOG_SEARCH_DEFAULT_TIMESPAN = (7 * 24 * 60 * 60 * 1000); //7 days
+export const LOG_SEARCH_DEFAULT_MAX_ENTRIES = 500;
+export const LOG_DEFAULT_ERROR_PERCENTAGE = 0.67;
+
+
 export let SAVE_LOGS_LOCALLY = (process.env.SAVE_LOGS_LOCALLY !== undefined) ? (process.env.SAVE_LOGS_LOCALLY === 'true') : true;
 export const setSaveLogsLocally = (saveLocally:boolean):void => { SAVE_LOGS_LOCALLY = saveLocally; }
 
@@ -22,6 +27,7 @@ export const setSaveAuthLogs = (saveAuthLogs:boolean):void => { SAVE_AUTH_LOGS =
 
 export let SAVE_EVENT_LOGS = (process.env.SAVE_EVENT_LOGS !== undefined) ? (process.env.SAVE_EVENT_LOGS === 'true') : true;
 export const setSaveEventLogs = (saveEventLogs:boolean):void => { SAVE_LOGS_LOCALLY = saveEventLogs; }
+
 
 /* S3 LOGGING Controls */
 export const MAX_PARALLEL_CONNECTIONS:number = (getEnvironment() === ENVIRONMENT_TYPE.LOCAL) ? 10 : 30;

--- a/1-src/2-services/10-utilities/logging/log-types.mts
+++ b/1-src/2-services/10-utilities/logging/log-types.mts
@@ -2,16 +2,26 @@ import { PathLike } from 'fs';
 import path from 'path';
 const __dirname = path.resolve();
 import { LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
+import { ENVIRONMENT_TYPE } from '../../../0-assets/field-sync/input-config-sync/inputField.mjs';
+import { getEnvironment } from '../utilities.mjs';
 
 
 /* LOGGING CONTROLS */
-export let SAVE_LOGS_LOCALLY = (process.env.SAVE_LOGS_LOCALLY !== undefined) ? (process.env.SAVE_LOGS_LOCALLY === 'true') :true;
+export let SAVE_LOGS_LOCALLY = (process.env.SAVE_LOGS_LOCALLY !== undefined) ? (process.env.SAVE_LOGS_LOCALLY === 'true') : true;
 export const setSaveLogsLocally = (saveLocally:boolean):void => { SAVE_LOGS_LOCALLY = saveLocally; }
 
-export const UPLOAD_LOGS = (process.env.SAVE_LOGS_DATABASE !== undefined) ? (process.env.SAVE_LOGS_DATABASE === 'true') :false;
+export const UPLOAD_LOGS_S3 = (process.env.UPLOAD_LOGS_S3 !== undefined) ? (process.env.UPLOAD_LOGS_S3 === 'true')
+                                : [ENVIRONMENT_TYPE.DEVELOPMENT, ENVIRONMENT_TYPE.PRODUCTION].includes(getEnvironment());
 
-export let SEND_ALERT_EMAILS = (process.env.SEND_EMAILS !== undefined) ? (process.env.SEND_EMAILS === 'true') :false;
-export const setSendAlertEmails = (sendAlert:boolean):void => { SEND_ALERT_EMAILS = sendAlert; }
+export let SEND_LOG_EMAILS = (process.env.SEND_LOG_EMAILS !== undefined) ? (process.env.SEND_LOG_EMAILS === 'true')
+                                : [ENVIRONMENT_TYPE.PRODUCTION].includes(getEnvironment());
+export const setSendAlertEmails = (sendAlert:boolean):void => { SEND_LOG_EMAILS = sendAlert; }
+
+export let SAVE_AUTH_LOGS = (process.env.SAVE_AUTH_LOGS !== undefined) ? (process.env.SAVE_AUTH_LOGS === 'true') : true;
+export const setSaveAuthLogs = (saveAuthLogs:boolean):void => { SAVE_AUTH_LOGS = saveAuthLogs; }
+
+export let SAVE_EVENT_LOGS = (process.env.SAVE_EVENT_LOGS !== undefined) ? (process.env.SAVE_EVENT_LOGS === 'true') : true;
+export const setSaveEventLogs = (saveEventLogs:boolean):void => { SAVE_LOGS_LOCALLY = saveEventLogs; }
 
 
 
@@ -43,7 +53,7 @@ export const getLogFilePath = (type:LogType):PathLike => {
 
 export enum LOG_SOURCE {
     NEW = 'NEW',
-    META_DATA = 'META_DATA',
+    S3_KEY = 'S3_KEY',
     JSON = 'JSON',
     TEXT = 'TEXT'
 }

--- a/1-src/2-services/10-utilities/logging/log.mts
+++ b/1-src/2-services/10-utilities/logging/log.mts
@@ -1,59 +1,66 @@
 import { LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
 import { writeLogFile } from './log-local-utilities.mjs';
-import { SAVE_LOGS_LOCALLY } from './log-types.mjs';
+import { uploadS3LogEntry } from './log-s3-utilities.mjs';
+import { SAVE_AUTH_LOGS, SAVE_EVENT_LOGS, SAVE_LOGS_LOCALLY, UPLOAD_LOGS_S3 } from './log-types.mjs';
 import LOG_ENTRY from './logEntryModel.mjs';
 
 /* EXPORT LOG BY TYPE */
-export const alert = async(...messages:any[]):Promise<Boolean> => {
+export const alert = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.ALERT, messages, getStackTrace());
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry);
-        // && await writeDatabase(LOG_TYPE.ALERT, entry)
-        // && await sendEmail('SERVER ALERT', entry);
+    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
+        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
+        // && !SEND_LOG_EMAILS || await sendLogAlertEmail(entry);
 }
 
-export const error = async(...messages:any[]):Promise<Boolean> => {
+export const error = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.ERROR, messages, getStackTrace());
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry);
-        // && await writeDatabase(LOG_TYPE.ERROR, entry)
+    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
+        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
 }
 
-export const errorWithoutTrace = async(...messages:any[]):Promise<Boolean> => {
+export const errorWithoutTrace = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.ERROR, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry);
-        // && await writeDatabase(LOG_TYPE.ERROR, entry)
+    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
+        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
 }
 
 export default error;
 
-export const warn = async(...messages:any[]):Promise<Boolean> => {
+export const warn = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.WARN, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry);
-        // && await writeDatabase(LOG_TYPE.WARN, entry)
+    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
+        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
 }
 
-export const db = async(...messages:any[]):Promise<Boolean> => {
+export const db = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.DB, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry);
-        // && await writeDatabase(LOG_TYPE.DB, entry)
+    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
+        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
 }
 
-export const auth = async(...messages:any[]):Promise<Boolean> => {
+export const auth = async(...messages:any[]):Promise<boolean> => {
+    if(!SAVE_AUTH_LOGS)
+        return true;
+    
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.AUTH, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry);
-        // && await writeDatabase(LOG_TYPE.AUTH, entry)
+    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
+        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
 }
 
-export const event = async(...messages:any[]):Promise<Boolean> => {
+export const event = async(...messages:any[]):Promise<boolean> => {
+    if(!SAVE_EVENT_LOGS)
+        return true;
+
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.EVENT, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry);
-        // && await writeDatabase(LOG_TYPE.EVENT, entry)
+    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
+        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
 }
 
 

--- a/1-src/2-services/10-utilities/logging/log.mts
+++ b/1-src/2-services/10-utilities/logging/log.mts
@@ -6,7 +6,7 @@ import LOG_ENTRY from './logEntryModel.mjs';
 
 /* EXPORT LOG BY TYPE */
 export const alert = async(...messages:any[]):Promise<boolean> => {
-    const entry:LOG_ENTRY = new LOG_ENTRY(LogType.ALERT, messages, getStackTrace());
+    const entry:LOG_ENTRY = new LOG_ENTRY(LogType.ERROR, ['ALERT', ...messages], getStackTrace());
 
     return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
         && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);

--- a/1-src/2-services/10-utilities/logging/log.mts
+++ b/1-src/2-services/10-utilities/logging/log.mts
@@ -8,23 +8,23 @@ import LOG_ENTRY from './logEntryModel.mjs';
 export const alert = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.ERROR, ['ALERT', ...messages], getStackTrace());
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
-        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
-        // && !SEND_LOG_EMAILS || await sendLogAlertEmail(entry);
+    return (!SAVE_LOGS_LOCALLY || await writeLogFile(entry))
+        && (!UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry));
+        // && (!SEND_LOG_EMAILS || await sendLogAlertEmail(entry));
 }
 
 export const error = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.ERROR, messages, getStackTrace());
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
-        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
+    return (!SAVE_LOGS_LOCALLY || await writeLogFile(entry))
+        && (!UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry));
 }
 
 export const errorWithoutTrace = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.ERROR, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
-        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
+    return (!SAVE_LOGS_LOCALLY || await writeLogFile(entry))
+        && (!UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry));
 }
 
 export default error;
@@ -32,15 +32,15 @@ export default error;
 export const warn = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.WARN, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
-        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
+    return (!SAVE_LOGS_LOCALLY || await writeLogFile(entry))
+        && (!UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry));
 }
 
 export const db = async(...messages:any[]):Promise<boolean> => {
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.DB, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
-        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
+    return (!SAVE_LOGS_LOCALLY || await writeLogFile(entry))
+        && (!UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry));
 }
 
 export const auth = async(...messages:any[]):Promise<boolean> => {
@@ -49,8 +49,8 @@ export const auth = async(...messages:any[]):Promise<boolean> => {
     
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.AUTH, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
-        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
+    return (!SAVE_LOGS_LOCALLY || await writeLogFile(entry))
+        && (!UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry));
 }
 
 export const event = async(...messages:any[]):Promise<boolean> => {
@@ -59,8 +59,8 @@ export const event = async(...messages:any[]):Promise<boolean> => {
 
     const entry:LOG_ENTRY = new LOG_ENTRY(LogType.EVENT, messages);
 
-    return !SAVE_LOGS_LOCALLY || await writeLogFile(entry)
-        && !UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry);
+    return (!SAVE_LOGS_LOCALLY || await writeLogFile(entry))
+        && (!UPLOAD_LOGS_S3 || await uploadS3LogEntry(entry));
 }
 
 

--- a/1-src/2-services/10-utilities/logging/logEntryModel.mts
+++ b/1-src/2-services/10-utilities/logging/logEntryModel.mts
@@ -21,11 +21,16 @@ export default class LOG_ENTRY {
     constructor(type:LogType, messages:string[], stackTrace:string[] = [], fileKey:string = '', date:Date = new Date(), source:LOG_SOURCE = LOG_SOURCE.NEW) {
         this.date = date;
         this.type = type;
-
-        this.messages = messages.map(m => (m === undefined) ? 'UNDEFINED' : (m === null) ? 'NULL' : (m.trim && m.trim().length === 0) ? 'BLANK' : m);
-        this.stackTrace = stackTrace.filter(m => m.length > 0);
         this.fileKey = fileKey;
         this.source = source;
+
+        this.messages = messages.map(m => 
+            (m === undefined) ? 'UNDEFINED' 
+            : (m === null) ? 'NULL' 
+            : (typeof m !== 'string') ? JSON.stringify(m)
+            : (m.trim && m.trim().length === 0) ? 'BLANK' : m);
+
+        this.stackTrace = stackTrace.filter(s => ((typeof s === 'string') && (s.length > 0)));
 
         if((this.source === LOG_SOURCE.NEW) && (getEnvironment() === ENVIRONMENT_TYPE.LOCAL)) this.print();
     }

--- a/1-src/2-services/10-utilities/logging/logEntryModel.mts
+++ b/1-src/2-services/10-utilities/logging/logEntryModel.mts
@@ -45,9 +45,8 @@ export default class LOG_ENTRY {
 
     static constructFromJSON = (json:any):LOG_ENTRY | undefined => {
         try {
-            const { timestamp, type, messages, stackTrace, fileKey, duplicateList } = json;
+            const { timestamp, type, messages, stackTrace, fileKey } = json;
             const logEntry:LOG_ENTRY = new LOG_ENTRY(type, messages, stackTrace ?? [], fileKey, new Date(timestamp), LOG_SOURCE.JSON);
-            logEntry.duplicateList = duplicateList;
 
             if(!logEntry.validate(LOG_SOURCE.JSON))
                 throw new Error(`Invalid ${LOG_SOURCE.JSON} Log:${JSON.stringify(logEntry.toJSON())}`);
@@ -208,7 +207,6 @@ export default class LOG_ENTRY {
 
     print = ():void => {
         switch (this.type) {
-            case LogType.ALERT:
             case LogType.ERROR:
                 return console.error(this.toString());
             case LogType.WARN:

--- a/1-src/2-services/10-utilities/logging/testLogEntryModel.mts
+++ b/1-src/2-services/10-utilities/logging/testLogEntryModel.mts
@@ -1,0 +1,74 @@
+import assert from 'node:assert';
+import { LogListItem, LogType } from "../../../0-assets/field-sync/api-type-sync/utility-types.mjs";
+import { LOG_SOURCE } from "./log-types.mjs";
+import LOG_ENTRY from "./logEntryModel.mjs";
+
+const entry = new LOG_ENTRY(
+    LogType.WARN,
+    [
+        'Error connecting to database - Initial connection attempt failed - timeout after 30 seconds Possible network issues - server overload - connection retries in progress',
+        'Database connection retry failed - Network congestion or server unresponsiveness - time limit reached Further attempts to reconnect scheduled - troubleshooting ongoing',
+        'Database connection established after retries - Network load balancing resolved issue - server responded after congestion cleared Query execution next step',
+        'Query execution failed - error code 500 - Database internal error, resource limits exceeded - retry mechanism triggered, still failing - impact on client requests under review',
+        'Query execution completed with partial results - Timeout occurred during execution - some data fetched, query failed for certain items - manual intervention required to complete operation'
+    ],
+    [
+        'Module.error = 118:19 => file:server/0-compiled/2-services/log.mjs | Module initialization failed - log service failure detected.',
+        'null = 314:13 => file:server/0-compiled/server.mjs | Unable to resolve endpoint - server down, further investigation required.',
+        'Layer.handle_error = 71:5 => node_modules/express/lib/router/layer.js | Error handler triggered | request processing halted due to critical failure - client notified.'
+    ],
+    undefined,
+    new Date('2025-01-30T23:59:15'),  //Local time
+    LOG_SOURCE.NEW
+);
+
+const testToStringThenConstructFromText = () => {
+    const str:string = entry.toString();
+    const newEntry:LOG_ENTRY = LOG_ENTRY.constructFromText(str);
+    
+    try {
+        assert.equal(newEntry.validateCheck(), true, 'testToStringThenConstructFromText - validation failed');
+        assert.equal(newEntry.equals(entry), true, 'testToStringThenConstructFromText -> equals match failed');
+    
+    } catch (error) {
+        newEntry.print();
+        console.log(newEntry.validate());
+        throw error;
+    }
+};
+
+const testToJsonThenConstructFromJson = () => {
+    const json:LogListItem = entry.toJSON();
+    const newEntry:LOG_ENTRY = LOG_ENTRY.constructFromJSON(json);
+    
+    try {
+        assert.equal(newEntry.validateCheck(), true, 'testToJsonThenConstructFromJson - validation failed');
+        assert.equal(newEntry.equals(entry), true, 'testToJsonThenConstructFromJson -> equals match failed');
+
+    } catch (error) {
+        newEntry.print();
+        console.log(newEntry.validate());
+        throw error;
+    }
+};
+
+const testCreateKeyThenConstructFromKey = () => {
+    const s3Key:string = entry.createS3Key();
+    const newEntry = LOG_ENTRY.constructFromS3Key(s3Key);
+    
+    try {
+        assert.equal(newEntry.validateCheck(), true, 'testCreateKeyThenConstructFromKey - validation failed');
+        assert.equal(newEntry.similar(entry), true, 'testCreateKeyThenConstructFromKey -> similar match failed');
+
+    } catch (error) {
+        newEntry.print();
+        console.log(newEntry.validate());
+        throw error;
+    }
+};
+
+export const executeLogTests = () => {
+    testToStringThenConstructFromText();
+    testToJsonThenConstructFromJson();
+    testCreateKeyThenConstructFromKey();
+};

--- a/1-src/2-services/10-utilities/logging/testLogEntryModel.mts
+++ b/1-src/2-services/10-utilities/logging/testLogEntryModel.mts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
-import { LogListItem, LogType } from "../../../0-assets/field-sync/api-type-sync/utility-types.mjs";
-import { LOG_SOURCE } from "./log-types.mjs";
-import LOG_ENTRY from "./logEntryModel.mjs";
+import { LogListItem, LogType } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
+import { LOG_SOURCE } from './log-types.mjs';
+import LOG_ENTRY from './logEntryModel.mjs';
 
 const entry = new LOG_ENTRY(
     LogType.WARN,

--- a/1-src/2-services/10-utilities/utilities.mts
+++ b/1-src/2-services/10-utilities/utilities.mts
@@ -1,3 +1,4 @@
+import { S3Client, ListBucketsCommand } from "@aws-sdk/client-s3";
 import { ENVIRONMENT_TYPE } from '../../0-assets/field-sync/input-config-sync/inputField.mjs';
 import { DATABASE_MODEL_SOURCE_ENVIRONMENT_ENUM } from '../2-database/database-types.mjs';
 import dotenv from 'dotenv';
@@ -19,6 +20,17 @@ export const getModelSourceEnvironment = (): DATABASE_MODEL_SOURCE_ENVIRONMENT_E
         ?? DATABASE_MODEL_SOURCE_ENVIRONMENT_ENUM.DEVELOPMENT;
 };
 
+/* AWS SSO Authentication | Provides access to S3 & SNS utilities */
+export const checkAWSAuthentication = async():Promise<boolean> => {
+    try { //Fetch list of buckets as a test
+        const s3Client = new S3Client({ region: process.env.LOG_BUCKET_REGION });
+        await s3Client.send(new ListBucketsCommand({}));       
+        return true;
+    } catch(error) {
+        console.error('WARNING - AWS Credentials Not Verified');
+        return false;
+    }
+}
 
 /*********************
  * GENERIC UTILITIES *

--- a/1-src/2-services/2-database/queries/user-queries.mts
+++ b/1-src/2-services/2-database/queries/user-queries.mts
@@ -163,7 +163,7 @@ export const DB_DELETE_USER = async(userID:number):Promise<boolean> => { //Note:
 
 
 //Checks all users in database, regardless of user.modelSourceEnvironment
-export const DB_UNIQUE_USER_EXISTS = async(filterMap:Map<string, any>, validateAllFields:boolean = true):Promise<Boolean|undefined> => { //(ALL columns and values are case insensitive)
+export const DB_UNIQUE_USER_EXISTS = async(filterMap:Map<string, any>, validateAllFields:boolean = true):Promise<boolean|undefined> => { //(ALL columns and values are case insensitive)
     //Validate Columns prior to Query | filter to only test valid columns
     const columnsLowerCase:string[] = USER_TABLE_COLUMNS.map(c => c.toLowerCase());
     const validFieldMap:Map<string, any> = new Map();  
@@ -200,7 +200,7 @@ export const DB_UNIQUE_USER_EXISTS = async(filterMap:Map<string, any>, validateA
 /**********************
  *  USER ROLE QUERIES
  **********************/
-export const DB_IS_USER_ROLE = async(userID:number, userRole:DATABASE_USER_ROLE_ENUM, useDefaultUser:boolean = false):Promise<Boolean> => {   
+export const DB_IS_USER_ROLE = async(userID:number, userRole:DATABASE_USER_ROLE_ENUM, useDefaultUser:boolean = false):Promise<boolean> => {   
     const rows = await execute('SELECT * ' + 'FROM user '
     + 'LEFT JOIN user_role ON user_role.userID = user.userID '
     + 'LEFT JOIN user_role_defined ON user_role_defined.userRoleID = user_role.userRoleID '
@@ -211,7 +211,7 @@ export const DB_IS_USER_ROLE = async(userID:number, userRole:DATABASE_USER_ROLE_
     return (rows.length === 1);
 }
 
-export const DB_IS_ANY_USER_ROLE = async(userID:number, userRoleList:DATABASE_USER_ROLE_ENUM[], useDefaultUser:boolean = true):Promise<Boolean> => {   
+export const DB_IS_ANY_USER_ROLE = async(userID:number, userRoleList:DATABASE_USER_ROLE_ENUM[], useDefaultUser:boolean = true):Promise<boolean> => {   
 
     if(userRoleList === undefined || userRoleList.length === 0) return false;
 

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -10,7 +10,7 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 
 //Import Types
-import { getEnvironment } from './2-services/10-utilities/utilities.mjs';
+import { checkAWSAuthentication, getEnvironment } from './2-services/10-utilities/utilities.mjs';
 import { ENVIRONMENT_TYPE, SUPPORTED_IMAGE_EXTENSION_LIST } from './0-assets/field-sync/input-config-sync/inputField.mjs';
 import { ServerDebugErrorResponse, ServerErrorResponse } from './0-assets/field-sync/api-type-sync/utility-types.mjs';
 import {Exception, JwtSearchRequest} from './1-api/api-types.mjs'
@@ -45,10 +45,11 @@ const SERVER_PORT = process.env.SERVER_PORT || 5000;
 const publicServer: Application = express();
 const apiServer: Application = express();
 
-/********************
-   Socket.IO Chat
- *********************/
+/************************
+* SERVER INITIALIZATION *
+*************************/
 const httpServer = createServer(apiServer).listen( SERVER_PORT, () => console.log(`Back End Server listening on HTTP port: ${SERVER_PORT} at ${SERVER_START_TIMESTAMP.toISOString()}`));
+await checkAWSAuthentication();
 
 
 //***LOCAL ENVIRONMENT****/ only HTTP | AWS uses loadBalancer to redirect HTTPS

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -20,7 +20,7 @@ import { JwtCircleClientRequest } from './1-api/4-circle/circle-types.mjs';
 
 //Import Routes
 import apiRoutes, { GET_createMockCircle, GET_createMockPrayerRequest, GET_createMockUser, POST_populateDemoUser } from './1-api/api.mjs';
-import { GET_LogDefaultList, GET_LogDownloadFile, GET_LogEntryByS3Key, GET_LogSearchList, POST_LogEmailReport, POST_LogEntry, POST_LogResetFile } from './1-api/1-utility/log.mjs';
+import { DELETE_LogEntryByS3Key, DELETE_LogEntryS3ByDay, GET_LogDefaultList, GET_LogDownloadFile, GET_LogEntryByS3Key, GET_LogSearchList, POST_LogEmailReport, POST_LogEntry, POST_LogResetFile } from './1-api/1-utility/log.mjs';
 import { authenticatePartnerMiddleware, authenticateCircleMembershipMiddleware, authenticateClientAccessMiddleware, authenticateCircleLeaderMiddleware, authenticateAdminMiddleware, jwtAuthenticationMiddleware, authenticateLeaderMiddleware, authenticatePrayerRequestRecipientMiddleware, authenticatePrayerRequestRequestorMiddleware, extractCircleMiddleware, extractClientMiddleware, authenticateContentApproverMiddleware, extractContentMiddleware, extractPartnerMiddleware, authenticatePendingPartnerMiddleware } from './1-api/2-auth/authorization.mjs';
 import { GET_userContacts } from './1-api/7-chat/chat.mjs';
 import { POST_JWTLogin, POST_login, POST_logout, POST_emailSubscribe, POST_resetPasswordAdmin } from './1-api/2-auth/auth.mjs';
@@ -355,6 +355,8 @@ apiServer.use(express.text());
 apiServer.delete('/api/admin/flush-search-cache/:type', (request:JwtSearchRequest, response:Response, next:NextFunction) => DELETE_flushSearchCacheAdmin(undefined, request, response, next)); //(Handles authentication)
 
 apiServer.get('/api/admin/log', GET_LogEntryByS3Key);
+apiServer.delete('/api/admin/log', DELETE_LogEntryByS3Key);
+apiServer.delete('/api/admin/log/day', DELETE_LogEntryS3ByDay);
 apiServer.get('/api/admin/log/default', GET_LogDefaultList);
 apiServer.get('/api/admin/log/:type', (request:LogSearchRequest, response:Response, next:NextFunction) => GET_LogSearchList(undefined, request, response, next));
 apiServer.post('/api/admin/log/:type', (request:LogEntryNewRequest, response:Response, next:NextFunction) => POST_LogEntry(undefined, request, response, next));

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -20,7 +20,7 @@ import { JwtCircleClientRequest } from './1-api/4-circle/circle-types.mjs';
 
 //Import Routes
 import apiRoutes, { GET_createMockCircle, GET_createMockPrayerRequest, GET_createMockUser, POST_populateDemoUser } from './1-api/api.mjs';
-import { DELETE_LogEntryByS3Key, DELETE_LogEntryS3ByDay, GET_LogDefaultList, GET_LogDownloadFile, GET_LogEntryByS3Key, GET_LogSearchList, POST_LogEmailReport, POST_LogEntry, POST_LogResetFile } from './1-api/1-utility/log.mjs';
+import { DELETE_LogEntryByS3Key, DELETE_LogEntryS3ByDay, GET_LogDefaultList, GET_LogDownloadFile, GET_LogEntryByS3Key, GET_LogSearchList, POST_LogEmailReport, POST_LogEntry, POST_LogPartitionBucket, POST_LogResetFile } from './1-api/1-utility/log.mjs';
 import { authenticatePartnerMiddleware, authenticateCircleMembershipMiddleware, authenticateClientAccessMiddleware, authenticateCircleLeaderMiddleware, authenticateAdminMiddleware, jwtAuthenticationMiddleware, authenticateLeaderMiddleware, authenticatePrayerRequestRecipientMiddleware, authenticatePrayerRequestRequestorMiddleware, extractCircleMiddleware, extractClientMiddleware, authenticateContentApproverMiddleware, extractContentMiddleware, extractPartnerMiddleware, authenticatePendingPartnerMiddleware } from './1-api/2-auth/authorization.mjs';
 import { GET_userContacts } from './1-api/7-chat/chat.mjs';
 import { POST_JWTLogin, POST_login, POST_logout, POST_emailSubscribe, POST_resetPasswordAdmin } from './1-api/2-auth/auth.mjs';
@@ -358,6 +358,7 @@ apiServer.get('/api/admin/log', GET_LogEntryByS3Key);
 apiServer.delete('/api/admin/log', DELETE_LogEntryByS3Key);
 apiServer.delete('/api/admin/log/day', DELETE_LogEntryS3ByDay);
 apiServer.get('/api/admin/log/default', GET_LogDefaultList);
+apiServer.post('/api/admin/log/athena-partition', POST_LogPartitionBucket);
 apiServer.get('/api/admin/log/:type', (request:LogSearchRequest, response:Response, next:NextFunction) => GET_LogSearchList(undefined, request, response, next));
 apiServer.post('/api/admin/log/:type', (request:LogEntryNewRequest, response:Response, next:NextFunction) => POST_LogEntry(undefined, request, response, next));
 apiServer.post('/api/admin/log/:type/reset', (request:LogEntryNewRequest, response:Response, next:NextFunction) => POST_LogResetFile(undefined, request, response, next));

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "server": "npm run serve",
     "start": "npm run build & npm run open & npm run serve",
     "update": "npm run website && npm run portal && npm run start",
-    "debug": "npm run build & npm run serve"
+    "debug": "npm run build & npm run serve",
+    "clean": "rimraf node_modules/ package-lock.json 0-compiled/"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.417.0",
     "@aws-sdk/client-secrets-manager": "^3.565.0",
     "@aws-sdk/client-sns": "^3.709.0",
-    "@types/dotenv": "^8.2.0",
     "@types/jsonwebtoken": "^9.0.2",
     "argon2": "^0.41.1",
     "axios": "^1.5.0",
@@ -39,7 +39,7 @@
     "metascraper-title": "^5.45.9",
     "mysql2": "3.11.3",
     "path": "^0.12.7",
-    "rimraf": "^3.0.2",
+    "rimraf": "5.0.10",
     "socket.io": "^4.5.4",
     "stack-trace": "^1.0.0-pre1",
     "ts-node": "9.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "server": "npm run serve",
     "start": "npm run build & npm run open & npm run serve",
     "update": "npm run website && npm run portal && npm run start",
-    "debug": "npm run build & npm run serve",
+    "debug": "aws sso login & npm run serve",
     "clean": "rimraf node_modules/ package-lock.json 0-compiled/"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean": "rimraf node_modules/ package-lock.json 0-compiled/"
   },
   "dependencies": {
+    "@aws-sdk/client-athena": "^3.744.0",
     "@aws-sdk/client-s3": "^3.417.0",
     "@aws-sdk/client-secrets-manager": "^3.565.0",
     "@aws-sdk/client-sns": "^3.709.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "mysql2": "3.11.3",
     "path": "^0.12.7",
     "rimraf": "5.0.10",
-    "rimraf": "5.0.10",
     "socket.io": "^4.5.4",
     "stack-trace": "^1.0.0-pre1",
     "ts-node": "9.1"


### PR DESCRIPTION
## Key Features

**Note: I wasn't sure how to handle logging errors related to log operations.  The normal `log.mts` process for errors of a entry that failed to save, creates an infinite loop.  So, depending on the operation I took a few approaches of writing directly to local file when possible and falling back to `console.log` when necessary.  For S3 errors, they are only written to a local log file.

1. **AWS Authentication**
    - Added `npm run debug` to call `aws sso login & npm run serve`
    - Check/reminder for AWS authentication added to `utilities.checkAWSAuthentication` in `server.mts`
    - Profile images and S3 log implementation now use `S3Client`

2. **S3 Log Design**
    - Logs saved both locally and uploaded to S3 bucket
    - Local logs auto-delete at file size; S3 logs will auto-delete in follow-up ticket
    - Portal view defaults: `LOCAL` for local environment, `S3` for `DEVELOPMENT` and `PRODUCTION`; settings menu to switch `Location`
    - Local and Development share same S3 bucket; separate for Production
    - Batch operations throttled (10/30); Athena queries timeout after 1min

3. **Log Searching**
    - S3 location search uses `Athena`
    - S3 bucket partitions: daily (e.g., `type=WARN/year=2025/month=02/day=13/`)
    - Manual partition schema update via `MSCK REPAIR TABLE ${tableName}`; saving timestamp triggers every 12h. Blocked locally due to constant server restarts

4. **Key Files**
    - [athena.mts](https://github.com/PEW35MINISTRY/server/compare/master...147-logs-s3#diff-009f43940ab5315f438fe7e5a123951170002320b7b802558b3b51d11ea27b92) modeled like `database.mts` for Athena queries
    - [log-s3-athena-search.mts](https://github.com/PEW35MINISTRY/server/compare/master...147-logs-s3#diff-440d454a38e8ce7c4159ebec0578ca93c287beae50eb1909706575dcef88094a) separate file for Athena search functionality
    - [log-s3-utilities.mts](https://github.com/PEW35MINISTRY/server/compare/master...147-logs-s3#diff-94a35f45f99f09f562b439c3c0cec59590a803f45b1d55740f448e3cb9a76b71) general S3 operations (fetch, upload, delete, batch)
    - [testLogEntryModel.mts](https://github.com/PEW35MINISTRY/server/compare/master...147-logs-s3#diff-6f63651996b3674864cfab35f337b4571e3f5e1f9d100cc2e5b189717d43dee5) test methods for parsing logs; not called, but kept for future unit tests

**Throughout:**
- Changed TypeScript types from class `Boolean` to primitive `boolean`
