### PR TITLE
147 | Logs - Missing Default

### DIFF
--- a/1-src/2-services/10-utilities/logging/log-s3-utilities.mts
+++ b/1-src/2-services/10-utilities/logging/log-s3-utilities.mts
@@ -97,7 +97,7 @@ export const fetchS3LogsByDay = async(type:LogType, date:Date = new Date(), maxE
 }
 
 export const fetchS3LogsByDateRange = async(type:LogType, startTimestamp?:number, endTimestamp?:number, maxEntries:number = LOG_SEARCH_DEFAULT_MAX_ENTRIES, mergeDuplicates:boolean = true):Promise<LOG_ENTRY[]> => {
-    const endDate = new Date(endTimestamp); //Default to today
+    const endDate = new Date(endTimestamp ?? new Date().getTime()); //Default to today
     endDate.setHours(0, 0, 0, 0);
     const startDate = new Date(startTimestamp ?? (endDate.getTime() - LOG_SEARCH_DEFAULT_TIMESPAN));
     const promiseQueue:Promise<LOG_ENTRY[]>[] = [];


### PR DESCRIPTION
### I missed default for `endTimeStamp`

This comes into effect for default log page where it's displaying the last 7 days or logs and `endTimestamp` is expected to default to current time.