### PR TITLE
remove host and database from DB_CONFIGURATIONS in prodiction env

### DIFF
--- a/1-src/2-services/2-database/database.mts
+++ b/1-src/2-services/2-database/database.mts
@@ -58,8 +58,6 @@ export const initializeDatabase = async():Promise<SQL.Pool> => {
     
         DB_CONFIGURATIONS = {
             ...DB_CONFIGURATIONS,
-            host: RDScredentials.host,
-            database: RDScredentials.dbname,
             user: RDScredentials.username,
             password: RDScredentials.password,
         };


### PR DESCRIPTION
Small oversight on my part.

In our production environment, the credentials for our database are managed by Secrets Manager. What I did not realize is that when this is enabled, the password is automatically rotated for us. While this is best practice, it breaks our server because we are retrieving the password from our own custom secret that includes the hostname and db name.

Because the secret managed by RDS includes the username and password in the same format we had already been using, it would make sense to just switch over to using this secret. However, our DB initialization code still copies over the hostname and db name from the secret result into the MySQL configuration. Because we cannot modify the secret, these hostname and database fields should be removed from the RDScredentialsobject and define them manually in env