### PR TITLE
[218] Improve Database Search

### DIFF
--- a/1-src/1-api/3-profile/profile-utilities.mts
+++ b/1-src/1-api/3-profile/profile-utilities.mts
@@ -27,7 +27,7 @@ export const filterContactList = async(request:JwtSearchRequest, contactList:Pro
     const searchTerm:string = request.query.search || '';
 
     if(searchTerm.length >= SEARCH_MIN_CHARS) {
-        const resultList = contactList.filter((contact:ProfileListItem) => `${contact.displayName} ${contact.firstName}`.includes(searchTerm));
+        const resultList = contactList.filter((contact:ProfileListItem) => `${contact.displayName ?? ''} ${contact.firstName ?? ''}`.toLowerCase().includes(searchTerm));
 
         //Indicates hit cache limit -> redirect to USER database search
         if(resultList.length === 0 && contactList.length === LIST_LIMIT) {

--- a/1-src/2-services/2-database/queries/content-queries.mts
+++ b/1-src/2-services/2-database/queries/content-queries.mts
@@ -120,8 +120,11 @@ export const DB_DELETE_CONTENT = async(contentID:number):Promise<boolean> => { /
 //https://code-boxx.com/mysql-search-exact-like-fuzzy/
 export const DB_SELECT_CONTENT_SEARCH = async(searchTerm:string, columnList:string[], limit:number = LIST_LIMIT):Promise<ContentListItem[]> => {
     const rows = await execute('SELECT contentID, type, customType, source, customSource, url, image, title, description, likeCount, keywordListStringified ' + 'FROM content '
-    + `WHERE ${(columnList.length == 1) ? columnList[0] : `CONCAT_WS( ${columnList.join(`, ' ', `)} )`} LIKE ? `
-    + `LIMIT ${limit};`, [`%${searchTerm}%`]);
+    + 'WHERE ( '
+        + columnList.map(column => `LOWER(${column}) LIKE LOWER(CONCAT("%", ?, "%"))`).join(' OR ')
+    + ' ) '
+    + `ORDER BY content.likeCount DESC `
+    + `LIMIT ${limit};`, [...Array(columnList.length).fill(`${searchTerm}`)]);
  
     return [...rows.map(row => ({contentID: row.contentID || -1, 
         type: row.type, 

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -59,7 +59,7 @@ await initializeDatabase();
 await checkAWSAuthentication();
 
 //*** CRON JOBS ***/
-if(getEnvironment() === ENVIRONMENT_TYPE.PRODUCTION) {
+if((process.env.ENABLE_CRON === 'true') && (getEnvironment() === ENVIRONMENT_TYPE.PRODUCTION)) {
   //Run at 15:00 UTC - 9am CST
   schedule("0 15 * * *", async () => answerAndNotifyPrayerRequests());
 


### PR DESCRIPTION
### Summary
Updated search queries  to use **explicit per-column `LIKE` matching** instead of `CONCAT_WS` combined fields. The previous approach caused missed matches due to ordering and spacing differences when concatenating fields.  `CONCAT_WS(firstName, lastName, displayName)` could fail when the search term appeared inside a single column but not in the combined string.  

### Example (Old vs New)
**Old (CONCAT) – fails:**  
`CONCAT_WS(' ', 'Sam', 'Hanson') LIKE '%han%'` → ❌ does not match `"Sam Hanson"` when spacing/punctuation differs.

**New (explicit) – works:**  
`LOWER(firstName) LIKE '%han%' OR LOWER(lastName) LIKE '%han%'` → ✅ correctly matches `"Hanson"`.

### Additional Changes
- Added 2 AM CST Production-only cache flush for user, contact, and circle search caches.
- Added `ENABLE_CRON` environment variable to distinguish main server if we ever scale horizontally