### PR TITLE
[274] Database Column Access

### DIFF
--- a/1-src/0-assets/field-sync/api-type-sync/circle-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/circle-types.mts
@@ -58,6 +58,8 @@ export interface CircleResponse {
     requestorID: number,
     requestorStatus: CircleStatusEnum
     image?: string,
+    createdDT: string,
+    modifiedDT: string,
 };
 
 export interface CircleLeaderResponse extends CircleResponse  {

--- a/1-src/0-assets/field-sync/api-type-sync/content-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/content-types.mts
@@ -22,6 +22,7 @@ export interface ContentListItem {
     description?: string, 
     image?: string,
     likeCount: number,
+    modifiedDT: string,
 }
 
 
@@ -42,7 +43,9 @@ export interface ContentResponseBody {
     maximumAge: number,
     minimumWalkLevel: number,
     maximumWalkLevel: number,
-    notes?: string
+    notes?: string,
+    createdDT: string,
+    modifiedDT: string,
 }
 
 export interface ContentMetaDataRequestBody {

--- a/1-src/0-assets/field-sync/api-type-sync/prayer-request-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/prayer-request-types.mts
@@ -14,11 +14,14 @@ import { CircleListItem } from './circle-types.mjs'
 *****************************************************************************************/
 
 export interface PrayerRequestListItem {
-    prayerRequestID: number,
-    requestorProfile: ProfileListItem, 
-    topic: string,
+    prayerRequestID:number,
+    requestorProfile:ProfileListItem, 
+    topic:string,
+    description:string,
+    tagList:PrayerRequestTagEnum[],
     prayerCount: number,
-    tagList?: PrayerRequestTagEnum[], 
+    createdDT:string,
+    modifiedDT:string
 }
 
 export interface PrayerRequestCommentListItem {
@@ -26,7 +29,8 @@ export interface PrayerRequestCommentListItem {
     prayerRequestID: number,
     commenterProfile: ProfileListItem, 
     message: string,
-    likeCount: number
+    likeCount: number,
+    createdDT:string,
 }
 
 export interface PrayerRequestResponseBody {
@@ -37,8 +41,11 @@ export interface PrayerRequestResponseBody {
     prayerCount: number,
     isOnGoing: boolean,
     isResolved: boolean,
-    tagList?: PrayerRequestTagEnum[],
+    tagList: PrayerRequestTagEnum[],
     expirationDate: string,
+    createdDT: string,
+    modifiedDT: string,
+
     commentList?: PrayerRequestCommentListItem[],
     userRecipientList?: ProfileListItem[],
     circleRecipientList?: CircleListItem[],

--- a/1-src/0-assets/field-sync/api-type-sync/profile-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/profile-types.mts
@@ -53,6 +53,7 @@ export interface ProfilePublicResponse extends ProfileListItem {
 
 export const PROFILE_PROPERTY_LIST = [ //Sync to ProfileResponse
     'userID', 'modelSourceEnvironment', 'displayName', 'firstName', 'lastName', 'email', 'gender', 'postalCode', 'dateOfBirth', 'emailVerified', 'maxPartners', 'walkLevel', 'notes', 'image',
+    'createdDT', 'modifiedDT', 
     'userRole', 'userRoleList',
     'circleList', 'circleInviteList', 'circleRequestList', 'circleAnnouncementList',
     'partnerList', 'partnerPendingUserList', 'partnerPendingPartnerList',
@@ -75,6 +76,9 @@ export interface ProfileResponse {
     walkLevel: number,
     notes?: string,
     image?: string,
+    createdDT: string,
+    modifiedDT: string,
+
     userRoleList: RoleEnum[],
     circleList?: CircleListItem[],
     circleInviteList?: CircleListItem[],

--- a/1-src/0-assets/field-sync/api-type-sync/utility-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/utility-types.mts
@@ -1,3 +1,7 @@
+/***** ONLY DEPENDENCY:./inputField - Define all other types locally *****/
+import { ENVIRONMENT_TYPE } from "../input-config-sync/inputField.mjs";
+import { RoleEnum } from "../input-config-sync/profile-field-config.mjs";
+
 
 /*********************************
 *    ADDITIONAL UTILITY TYPES    *
@@ -54,3 +58,29 @@ export type LogListItem = {
     fileKey?:string; 
     duplicateList?:string[]; 
 };
+
+
+/* ADMIN DASHBOARD STATISTICS */
+export type AdminStatsResponse = {
+  generatedDT:string,
+  environment:ENVIRONMENT_TYPE,
+  databaseUsageMap:Record<string, DatabaseTableUsage>,
+  userStats:DatabaseUserStats,
+}
+
+export interface DatabaseTableUsage {
+    totalRows:number,
+    created24Hours:number,
+    created7Days:number,
+    created30Days:number,
+    modified24Hours:number,
+    modified7Days:number,
+    modified30Days:number,
+}
+
+export interface DatabaseUserStats extends DatabaseTableUsage {
+    emailVerified:number,
+    walkLevelMap:Record<number, number>,
+    roleMap:Record<RoleEnum, number>,
+    unassignedUsers:number,
+}

--- a/1-src/0-assets/field-sync/input-config-sync/circle-field-config.mts
+++ b/1-src/0-assets/field-sync/input-config-sync/circle-field-config.mts
@@ -52,6 +52,9 @@ export const CIRCLE_FIELDS:InputField[] = [
 ];
 
 export const CIRCLE_FIELDS_ADMIN:InputField[] = [
+    new InputField({title: 'Circle ID', field: 'circleID', type: InputType.READ_ONLY }),
+    new InputField({title: 'Circle Created', field: 'createdDT', type: InputType.READ_ONLY }),
+    new InputField({title: 'Last Modified', field: 'modifiedDT', type: InputType.READ_ONLY }), 
     new InputField({title: 'Leader ID', field: 'leaderID', type: InputType.NUMBER,  required: true }),
     new InputSelectionField({title: 'Active Account', field: 'isActive', required: true, type: InputType.SELECT_LIST, selectOptionList: ['true', 'false']}),
     ...CIRCLE_FIELDS,
@@ -60,7 +63,7 @@ export const CIRCLE_FIELDS_ADMIN:InputField[] = [
 ];
 
 export const CIRCLE_ANNOUNCEMENT_FIELDS:InputField[] = [
-    new InputField({title: 'Announcement', field: 'message',  required: true, type: InputType.TEXT, length:{min: 1, max: 100} }),
+    new InputField({title: 'Announcement', field: 'message',  required: true, type: InputType.PARAGRAPH, length:{min: 1, max: 100} }),
     new InputField({title: 'Display Date', field: 'startDate', type: InputType.DATE, value: getDateDaysFuture(0).toISOString(), required: true, validationRegex: DATE_REGEX }),
     new InputField({title: 'Expiration Date', field: 'endDate', type: InputType.DATE, value: getDateDaysFuture(14).toISOString(), required: true, validationRegex: DATE_REGEX }),
 ];

--- a/1-src/0-assets/field-sync/input-config-sync/content-field-config.mts
+++ b/1-src/0-assets/field-sync/input-config-sync/content-field-config.mts
@@ -104,7 +104,10 @@ sourceField.selectOptionList.forEach((source:string, index:number) => {
         sourceField.displayOptionList[index] = `${makeDisplayText(source)} (mobile)`;
 });
 
-export const EDIT_CONTENT_FIELDS_ADMIN:InputField[] = [    
+export const EDIT_CONTENT_FIELDS_ADMIN:InputField[] = [   
+    new InputField({title: 'Content ID', field: 'contentID', type: InputType.READ_ONLY }),
+    new InputField({title: 'Created', field: 'createdDT', type: InputType.READ_ONLY }),
+    new InputField({title: 'Last Modified', field: 'modifiedDT', type: InputType.READ_ONLY }),  
     ...EDIT_CONTENT_FIELDS,
     new InputField({title: 'Recorder ID', field: 'recorderID', type: InputType.NUMBER }),
     new InputField({title: 'Notes', field: 'notes', type: InputType.PARAGRAPH, length:{min: 0, max: 3000} }),

--- a/1-src/0-assets/field-sync/input-config-sync/inputField.mts
+++ b/1-src/0-assets/field-sync/input-config-sync/inputField.mts
@@ -22,6 +22,7 @@ export enum DeviceOSEnum {
 }
 
 export enum InputType {
+    READ_ONLY = 'READ_ONLY',              //Display as a string
     CUSTOM = 'CUSTOM',
     TEXT = 'TEXT',
     NUMBER = 'NUMBER',
@@ -96,6 +97,7 @@ export default class InputField {
 
         /* Validations */
         if(this.length && (typeof this.length.min !== 'number' || typeof this.length.max !== 'number' || this.length.min > this.length.max)) throw new Error(`InputSelectionField - ${this.field} - Invalid length: ${JSON.stringify(this.length)}`);
+        if(this.type === InputType.READ_ONLY && (this.required || this.unique || this.length !== undefined || validationRegex !== undefined || validationMessage !== undefined || this.customField !== undefined)) throw new Error(`InputSelectionField - ${this.field} - READ_ONLY fields cannot be required, unique, or define length/validation/customField`);
     };
 
     setValue(value: string): void {this.value = value; }

--- a/1-src/0-assets/field-sync/input-config-sync/prayer-request-field-config.mts
+++ b/1-src/0-assets/field-sync/input-config-sync/prayer-request-field-config.mts
@@ -21,6 +21,8 @@ export enum PrayerRequestTagEnum {
     GLOBAL = 'GLOBAL'
 }
 
+export const DEFAULT_PRAYER_REQUEST_EXPIRATION_DAYS:number = 14;
+
 export const PrayerRequestDurationsMap = new Map<string, string>([ //Used as InputSelectionField, must be strings
     ['2 Days', '2'],
     ['7 Days', '7'],
@@ -57,11 +59,14 @@ export const EDIT_PRAYER_REQUEST_FIELDS:InputField[] = [
 ];
 
 export const PRAYER_REQUEST_FIELDS_ADMIN:InputField[] = [
+    new InputField({title: 'Prayer Request ID', field: 'prayerRequestID', type: InputType.READ_ONLY }),
+    new InputField({title: 'Created', field: 'createdDT', type: InputType.READ_ONLY }),
+    new InputField({title: 'Last Modified', field: 'modifiedDT', type: InputType.READ_ONLY }), 
     new InputSelectionField({title: 'Status', field: 'isResolved', value: 'false', type: InputType.SELECT_LIST, selectOptionList: ['true', 'false'], displayOptionList: ['Inactive', 'Active']}),
     ...EDIT_PRAYER_REQUEST_FIELDS,
     new InputSelectionField({title: 'Remind Me', field: 'isOnGoing', value: 'false', type: InputType.SELECT_LIST, selectOptionList: ['true', 'false'], displayOptionList: ['Yes', 'No']}),
-    new InputField({title: 'Expiration Date', field: 'expirationDate', type: InputType.DATE, value: getDateDaysFuture(7).toISOString(), validationRegex: DATE_REGEX, validationMessage: 'Must be future date.' }),
-    new InputField({title: 'Prayer Count', field: 'prayerCount', type: InputType.NUMBER})
+    new InputField({title: 'Expiration Date', field: 'expirationDate', type: InputType.DATE, value: getDateDaysFuture(DEFAULT_PRAYER_REQUEST_EXPIRATION_DAYS).toISOString(), validationRegex: DATE_REGEX, validationMessage: 'Must be future date.' }),
+    new InputField({title: 'Prayer Count', field: 'prayerCount', type: InputType.READ_ONLY})
 ];
 
 export const PRAYER_REQUEST_COMMENT_FIELDS:InputField[] = [

--- a/1-src/0-assets/field-sync/input-config-sync/profile-field-config.mts
+++ b/1-src/0-assets/field-sync/input-config-sync/profile-field-config.mts
@@ -109,7 +109,10 @@ export const EDIT_PROFILE_FIELDS:InputField[] = [
     new InputField({title: 'Postal Code', field: 'postalCode', type: InputType.TEXT, required: true, length:{min:5, max:15}, validationRegex:PLAIN_TEXT_REGEX}),
 ];
 
-export const EDIT_PROFILE_FIELDS_ADMIN:InputField[] = [    
+export const EDIT_PROFILE_FIELDS_ADMIN:InputField[] = [
+    new InputField({title: 'User ID', field: 'userID', type: InputType.READ_ONLY }),
+    new InputField({title: 'Account Created', field: 'createdDT', type: InputType.READ_ONLY }),
+    new InputField({title: 'Last Modified', field: 'modifiedDT', type: InputType.READ_ONLY }),   
     new InputSelectionField({title: 'Account Type', field: 'userRoleTokenList', type: InputType.CUSTOM, selectOptionList: Object.values(RoleEnum) }),
     new InputSelectionField({title: 'Source Environment', field: 'modelSourceEnvironment', required: true, type: InputType.SELECT_LIST, selectOptionList: Object.values(ModelSourceEnvironmentEnum), environmentList:[ENVIRONMENT_TYPE.DEVELOPMENT]}),
     new InputField({title: 'Email Address', field: 'email', type: InputType.EMAIL, required: true, unique: true,  validationRegex: EMAIL_REGEX }),

--- a/1-src/1-api/4-circle/circle.mts
+++ b/1-src/1-api/4-circle/circle.mts
@@ -50,7 +50,7 @@ export const GET_circle =  async(request: JwtCircleRequest, response: Response, 
     //Additional MEMBER Detail Queries
     } else if([CircleStatusEnum.MEMBER, CircleStatusEnum.LEADER].includes(circle.requestorStatus) || (request.jwtUserRole === RoleEnum.ADMIN)) { 
         circle.announcementList = await DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT(request.circleID);
-        circle.prayerRequestList = await DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST( circle.circleID);
+        circle.prayerRequestList = await DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST(circle.circleID, request.jwtUserID);
     }
         
     if(circle.requestorStatus === CircleStatusEnum.MEMBER && (request.jwtUserRole !== RoleEnum.ADMIN)) {
@@ -98,7 +98,7 @@ export const POST_newCircle =  async(request: JwtRequest, response: Response, ne
         else if(await DB_IS_USER_ROLE(newCircle.leaderID, DATABASE_USER_ROLE_ENUM.CIRCLE_LEADER) === false)
             next(new Exception(401, `Edit Circle Failed :: failed to verify leader status of userID: ${newCircle.leaderID}`, 'Leader status not verified.'));
 
-        else if(await DB_INSERT_CIRCLE(newCircle.getDatabaseProperties()) === false) 
+        else if((await DB_INSERT_CIRCLE(newCircle.getDatabaseProperties())).success === false) 
                 next(new Exception(500, 'Create Circle  Failed :: Failed to save new circle to database.', 'Save Failed'));
 
         else {
@@ -138,6 +138,7 @@ export const PATCH_circle =  async(request: JwtCircleRequest, response: Response
         else {
             editCircle.requestorID = request.jwtUserID;
             editCircle.requestorStatus = CircleStatusEnum.LEADER;
+            editCircle.modifiedDT = new Date(); //Local update, database sets modifiedDT
 
             response.status(202).send(editCircle.toLeaderJSON());
         }
@@ -234,10 +235,13 @@ export const POST_circleAnnouncement =  async(request: CircleAnnouncementCreateR
         newCircleAnnouncement.circleID = request.circleID;
         
         if(CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED.every((column) => newCircleAnnouncement[column] !== undefined) === false) 
-            next(new Exception(400, `Create Circle Announcement Failed :: Missing Required Fields: ${JSON.stringify(CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED)}.`, 'Missing Details'));
+            return next(new Exception(400, `Create Circle Announcement Failed :: Missing Required Fields: ${JSON.stringify(CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED)}.`, 'Missing Details'));
 
-        else if(await DB_INSERT_CIRCLE_ANNOUNCEMENT(newCircleAnnouncement.getDatabaseProperties()) === false) 
-                next(new Exception(500, 'Create Circle Announcement Failed :: Failed to save new circle announcement.', 'Save Failed'));
+        const insertResponse:{success:boolean, announcementID:number} = await DB_INSERT_CIRCLE_ANNOUNCEMENT(newCircleAnnouncement.getDatabaseProperties());
+        newCircleAnnouncement.announcementID = insertResponse.announcementID;
+        
+        if(!insertResponse.success || insertResponse.announcementID <= 0) 
+            next(new Exception(500, 'Create Circle Announcement Failed :: Failed to save new circle announcement.', 'Save Failed'));
 
         else
             response.status(202).send(newCircleAnnouncement.toJSON());

--- a/1-src/1-api/8-notification/notification-utilities.mts
+++ b/1-src/1-api/8-notification/notification-utilities.mts
@@ -47,12 +47,14 @@ const publishNotifications = async(endpointARNs:string[], message:string):Promis
 const publishNotificationPairedMessages = async(endPointMessageMap: Map<string, string>):Promise<boolean> => {
     const publishPromises = Array.from(endPointMessageMap.entries()).map(async ([endpoint, message]:[string, string]) => {
         try {
-            await snsClient.send(new PublishCommand({
-                TargetArn: endpoint,
-                Message: message,
-                MessageAttributes: SNS_APNS_HEADERS,
-                MessageStructure: 'json'
-            }));
+            if(getEnvironment() !== ENVIRONMENT_TYPE.LOCAL || process.env.SEND_NOTIFICATIONS === 'true') {
+                await snsClient.send(new PublishCommand({
+                    TargetArn: endpoint,
+                    Message: message,
+                    MessageAttributes: SNS_APNS_HEADERS,
+                    MessageStructure: 'json'
+                }));
+            }
             return true;
 
         } catch (error) {

--- a/1-src/1-api/api.mts
+++ b/1-src/1-api/api.mts
@@ -10,6 +10,9 @@ import PRAYER_REQUEST from '../2-services/1-models/prayerRequestModel.mjs';
 import { getEnvironment } from '../2-services/10-utilities/utilities.mjs';
 import { ENVIRONMENT_TYPE } from '../0-assets/field-sync/input-config-sync/inputField.mjs';
 import { answerAndNotifyPrayerRequests } from '../3-lambda/prayer-request/prayer-request-expired-script.mjs';
+import { AdminStatsResponse } from '../0-assets/field-sync/api-type-sync/utility-types.mjs';
+import { DB_CALCULATE_TABLE_USAGE, DB_CALCULATE_USER_TABLE_STATS } from '../2-services/2-database/queries/queries.mjs';
+import { DATABASE_TABLE } from '../2-services/2-database/database-types.mjs';
 
 const router:Router = express.Router();
 
@@ -22,6 +25,20 @@ router.get('/', (request: Request, response: Response) => {
 
 export default router;
 
+
+/*******************
+ * ADMIN UTILITIES *
+ *******************/
+export const GET_AdminStatistics = async(request:JwtAdminRequest, response:Response, next:NextFunction) =>
+    response.status(200).json({
+        generatedDT: new Date().toISOString(),
+        environment: getEnvironment(),
+
+        databaseUsageMap: Object.fromEntries(await Promise.all(
+                Object.values(DATABASE_TABLE).map(async (table) => [table, await DB_CALCULATE_TABLE_USAGE(table)]))),
+
+        userStats: await DB_CALCULATE_USER_TABLE_STATS(),
+    } satisfies AdminStatsResponse);
 
 
 /******************

--- a/1-src/2-services/1-models/baseModel.mts
+++ b/1-src/2-services/1-models/baseModel.mts
@@ -28,9 +28,10 @@ export default abstract class BASE_MODEL<Model, ListItem, JsonResponse> {
     set ID(id:number) { this[this.IDProperty] = id; }
 
     /* Must Override Property Lists */        
-    abstract get DATABASE_COLUMN_LIST():string[];
-    abstract get DATABASE_IDENTIFYING_PROPERTY_LIST():string[];
-    abstract get PROPERTY_LIST():string[];
+    abstract get DATABASE_COLUMN_LIST():string[];                 //Read DB Columns
+    abstract get DATABASE_COLUMN_EDIT_LIST():string[];            //Editable DB Columns
+    abstract get DATABASE_IDENTIFYING_PROPERTY_LIST():string[];   //Unique DB Columns that are searchable
+    abstract get PROPERTY_LIST():string[];                        //All Model Properties (May write to model from JSON, if also in input config)
 
     /* Optional: Override Ordering for dependent properties | Includes all: model, json, and database properties */
     #priorityInputList:string[] = [];
@@ -56,10 +57,10 @@ export default abstract class BASE_MODEL<Model, ListItem, JsonResponse> {
       BASE_MODEL.getUniquePropertiesUtility<BASE_MODEL<Model, ListItem, JsonResponse>>({fieldList: properties, getModelProperty: (property) => property,
           model: this, baseModel: undefined, includeID: includeUserID, includeObjects: true, includeNull: false, complexFieldMap: new Map()});
   
-    getDatabaseProperties = ():Map<string, any> => this.getValidProperties(this.DATABASE_COLUMN_LIST, false);
+    getDatabaseProperties = ():Map<string, any> => this.getValidProperties(this.DATABASE_COLUMN_EDIT_LIST, false);
 
     static getUniqueDatabasePropertiesDefault = <M extends BASE_MODEL<any, any, any>>(model:M, baseModel:M):Map<string, any> =>
-      BASE_MODEL.getUniquePropertiesUtility<M>({fieldList: model.DATABASE_COLUMN_LIST, getModelProperty: (column) => model.getPropertyFromDatabaseColumn(column) ? column : undefined,
+      BASE_MODEL.getUniquePropertiesUtility<M>({fieldList: model.DATABASE_COLUMN_EDIT_LIST, getModelProperty: (column) => model.getPropertyFromDatabaseColumn(column) ? column : undefined,
           model, baseModel, includeID: false, includeObjects: false, includeNull: true});
 
     getUniqueDatabaseProperties = (baseModel:this):Map<string, any> => (this.constructor as typeof BASE_MODEL).getUniqueDatabasePropertiesDefault(this, baseModel);

--- a/1-src/2-services/1-models/circleAnnouncementModel.mts
+++ b/1-src/2-services/1-models/circleAnnouncementModel.mts
@@ -3,7 +3,7 @@ import InputField, { InputType } from '../../0-assets/field-sync/input-config-sy
 import { JwtClientRequest } from '../../1-api/2-auth/auth-types.mjs';
 import { CircleAnnouncementCreateRequest } from '../../1-api/4-circle/circle-types.mjs';
 import { Exception } from '../../1-api/api-types.mjs';
-import { CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS, DATABASE_CIRCLE_ANNOUNCEMENT } from '../2-database/database-types.mjs';
+import { CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS, CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_EDIT, DATABASE_CIRCLE_ANNOUNCEMENT } from '../2-database/database-types.mjs';
 import BASE_MODEL from './baseModel.mjs';
 
 
@@ -12,13 +12,17 @@ export default class CIRCLE_ANNOUNCEMENT extends BASE_MODEL<CIRCLE_ANNOUNCEMENT,
 
     //Private static list of class property fields | (This is display-responses; NOT edit-access.)
     static DATABASE_IDENTIFYING_PROPERTY_LIST = ['circleID', 'message']; //exclude: announcementID, complex types, and lists
-    static PROPERTY_LIST = [ 'announcementID', 'circleID', 'message', 'startDate', 'endDate'];
+    static PROPERTY_LIST = [ 'announcementID', 'circleID', 'message', 'startDate', 'endDate', 'createdDT'];
 
     announcementID: number = -1;
     circleID: number = -1;
     message: string;
     startDate: Date;
     endDate: Date;
+
+    //Database - Read Only
+    createdDT:Date;
+    modifiedDT:Date;
 
     //Used as error case or blank
     constructor(id:number = -1) {
@@ -43,6 +47,7 @@ export default class CIRCLE_ANNOUNCEMENT extends BASE_MODEL<CIRCLE_ANNOUNCEMENT,
     override get IDProperty():string { return 'announcementID'; }
 
     override get DATABASE_COLUMN_LIST():string[] { return CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS; }
+    override get DATABASE_COLUMN_EDIT_LIST():string[] { return CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_EDIT; }
     override get DATABASE_IDENTIFYING_PROPERTY_LIST():string[] { return CIRCLE_ANNOUNCEMENT.DATABASE_IDENTIFYING_PROPERTY_LIST; }
     override get PROPERTY_LIST():string[] { return CIRCLE_ANNOUNCEMENT.PROPERTY_LIST; }
 

--- a/1-src/2-services/1-models/circleModel.mts
+++ b/1-src/2-services/1-models/circleModel.mts
@@ -5,7 +5,7 @@ import { CircleStatusEnum } from '../../0-assets/field-sync/input-config-sync/ci
 import InputField from '../../0-assets/field-sync/input-config-sync/inputField.mjs';
 import { JwtClientRequest } from '../../1-api/2-auth/auth-types.mjs';
 import { Exception } from '../../1-api/api-types.mjs';
-import { CIRCLE_TABLE_COLUMNS, DATABASE_CIRCLE } from '../2-database/database-types.mjs';
+import { CIRCLE_TABLE_COLUMNS, CIRCLE_TABLE_COLUMNS_EDIT, DATABASE_CIRCLE } from '../2-database/database-types.mjs';
 import BASE_MODEL from './baseModel.mjs';
 import CIRCLE_ANNOUNCEMENT from './circleAnnouncementModel.mjs';
 
@@ -18,7 +18,7 @@ export default class CIRCLE extends BASE_MODEL<CIRCLE, CircleListItem, CircleRes
     static PUBLIC_PROPERTY_LIST = ['circleID', 'leaderID', 'name', 'description', 'postalCode', 'image', 'requestorID', 'requestorStatus', 'leaderProfile', 'memberList', 'eventList'];
     static MEMBER_PROPERTY_LIST = [...CIRCLE.PUBLIC_PROPERTY_LIST, 'announcementList', 'prayerRequestList', 'pendingRequestList', 'pendingInviteList'];
     static LEADER_PROPERTY_LIST = [...CIRCLE.MEMBER_PROPERTY_LIST, 'inviteToken'];
-    static PROPERTY_LIST = [...CIRCLE.LEADER_PROPERTY_LIST, 'isActive','notes'];
+    static PROPERTY_LIST = [...CIRCLE.LEADER_PROPERTY_LIST, 'isActive','notes', 'createdDT', 'modifiedDT'];
 
     circleID: number = -1;
     leaderID: number;
@@ -29,6 +29,10 @@ export default class CIRCLE extends BASE_MODEL<CIRCLE, CircleListItem, CircleRes
     inviteToken?: string;
     image?: string;
     notes?: string;
+
+    //Database - Read Only
+    createdDT:Date;
+    modifiedDT:Date;
 
     //Query separate Tables
     requestorID: number = -1;
@@ -55,6 +59,7 @@ export default class CIRCLE extends BASE_MODEL<CIRCLE, CircleListItem, CircleRes
     override get IDProperty():string { return 'circleID'; }
 
     override get DATABASE_COLUMN_LIST():string[] { return CIRCLE_TABLE_COLUMNS; }
+    override get DATABASE_COLUMN_EDIT_LIST():string[] { return CIRCLE_TABLE_COLUMNS_EDIT; }    
     override get DATABASE_IDENTIFYING_PROPERTY_LIST():string[] { return CIRCLE.DATABASE_IDENTIFYING_PROPERTY_LIST; }
     override get PROPERTY_LIST():string[] { return CIRCLE.PROPERTY_LIST; }
     

--- a/1-src/2-services/1-models/contentArchiveModel.mts
+++ b/1-src/2-services/1-models/contentArchiveModel.mts
@@ -15,7 +15,7 @@ export default class CONTENT_ARCHIVE extends BASE_MODEL<CONTENT_ARCHIVE, Content
 
     //Private static list of class property fields | (This is display-responses; NOT edit-access.)
     static DATABASE_IDENTIFYING_PROPERTY_LIST = [ 'recorderID', 'type', 'source', 'url' ]; //exclude: contentID, complex types, and lists
-    static PROPERTY_LIST = [ 'contentID', 'recorderID', 'type', 'customType', 'source', 'customSource', 'url', 'keywordList', 'title', 'description', 'image', 'likeCount', 'gender', 'minimumAge', 'maximumAge', 'minimumWalkLevel', 'maximumWalkLevel', 'notes', 'recorderProfile' ];
+    static PROPERTY_LIST = [ 'contentID', 'recorderID', 'type', 'customType', 'source', 'customSource', 'url', 'keywordList', 'title', 'description', 'image', 'likeCount', 'gender', 'minimumAge', 'maximumAge', 'minimumWalkLevel', 'maximumWalkLevel', 'notes', 'recorderProfile', 'createdDT', 'modifiedDT' ];
 
     contentID: number = -1;
     recorderID: number; //user that recorded
@@ -35,6 +35,10 @@ export default class CONTENT_ARCHIVE extends BASE_MODEL<CONTENT_ARCHIVE, Content
     minimumWalkLevel: number;
     maximumWalkLevel: number; 
     notes?: string;
+
+    //Database - Read Only
+    createdDT:Date;
+    modifiedDT:Date;
 
     //Query separate Tables
     recorderProfile?: ProfileListItem;
@@ -80,6 +84,7 @@ export default class CONTENT_ARCHIVE extends BASE_MODEL<CONTENT_ARCHIVE, Content
     override get IDProperty():string { return 'contentID'; }
  
     override get DATABASE_COLUMN_LIST():string[] { return CONTENT_TABLE_COLUMNS; }
+    override get DATABASE_COLUMN_EDIT_LIST():string[] { return CONTENT_TABLE_COLUMNS; }
     override get DATABASE_IDENTIFYING_PROPERTY_LIST():string[] { return CONTENT_ARCHIVE.DATABASE_IDENTIFYING_PROPERTY_LIST; }
     override get PROPERTY_LIST():string[] { return CONTENT_ARCHIVE.PROPERTY_LIST; }
 

--- a/1-src/2-services/1-models/contentArchiveModel.mts
+++ b/1-src/2-services/1-models/contentArchiveModel.mts
@@ -4,7 +4,7 @@ import { ContentSourceEnum, ContentTypeEnum, GenderSelectionEnum } from '../../0
 import InputField from '../../0-assets/field-sync/input-config-sync/inputField.mjs';
 import { JwtClientRequest } from '../../1-api/2-auth/auth-types.mjs';
 import { Exception } from '../../1-api/api-types.mjs';
-import {  CONTENT_TABLE_COLUMNS, DATABASE_CONTENT } from '../2-database/database-types.mjs';
+import {  CONTENT_TABLE_COLUMNS, CONTENT_TABLE_COLUMNS_EDIT, DATABASE_CONTENT } from '../2-database/database-types.mjs';
 import * as log from '../10-utilities/logging/log.mjs';
 import BASE_MODEL from './baseModel.mjs';
 
@@ -84,7 +84,7 @@ export default class CONTENT_ARCHIVE extends BASE_MODEL<CONTENT_ARCHIVE, Content
     override get IDProperty():string { return 'contentID'; }
  
     override get DATABASE_COLUMN_LIST():string[] { return CONTENT_TABLE_COLUMNS; }
-    override get DATABASE_COLUMN_EDIT_LIST():string[] { return CONTENT_TABLE_COLUMNS; }
+    override get DATABASE_COLUMN_EDIT_LIST():string[] { return CONTENT_TABLE_COLUMNS_EDIT; }
     override get DATABASE_IDENTIFYING_PROPERTY_LIST():string[] { return CONTENT_ARCHIVE.DATABASE_IDENTIFYING_PROPERTY_LIST; }
     override get PROPERTY_LIST():string[] { return CONTENT_ARCHIVE.PROPERTY_LIST; }
 
@@ -143,7 +143,9 @@ export default class CONTENT_ARCHIVE extends BASE_MODEL<CONTENT_ARCHIVE, Content
         source: this.source,  
         url: this.url, image: this.image,
         title: this.title, description: this.description, 
-        keywordList: this.keywordList, likeCount: this.likeCount});
+        keywordList: this.keywordList, likeCount: this.likeCount,
+        modifiedDT: this.modifiedDT ? this.modifiedDT.toISOString() : new Date().toISOString(),
+    });
 
 
    /*****************************************

--- a/1-src/2-services/1-models/userModel.mts
+++ b/1-src/2-services/1-models/userModel.mts
@@ -5,7 +5,7 @@ import InputField, { InputSelectionField, InputType } from '../../0-assets/field
 import { GenderEnum, ModelSourceEnvironmentEnum, RoleEnum, getDOBMaxDate, getDOBMinDate } from '../../0-assets/field-sync/input-config-sync/profile-field-config.mjs';
 import BiDirectionalMap from '../../0-assets/modules/BiDirectionalMap.mjs';
 import { ProfileEditRequest } from '../../1-api/3-profile/profile-types.mjs';
-import { DATABASE_USER, USER_TABLE_COLUMNS } from '../2-database/database-types.mjs';
+import { DATABASE_USER, USER_TABLE_COLUMNS, USER_TABLE_COLUMNS_EDIT } from '../2-database/database-types.mjs';
 import * as log from '../10-utilities/logging/log.mjs';
 import BASE_MODEL from './baseModel.mjs';
 import { JwtClientRequest } from '../../1-api/2-auth/auth-types.mjs';
@@ -42,6 +42,10 @@ export default class USER extends BASE_MODEL<USER, ProfileListItem, ProfileRespo
   maxPartners: number;
   image?: string;
   notes?: string;
+
+    //Database - Read Only
+    createdDT:Date;
+    modifiedDT:Date;
 
   //Query separate Tables
   userRoleList: RoleEnum[] = [RoleEnum.USER];
@@ -95,6 +99,7 @@ export default class USER extends BASE_MODEL<USER, ProfileListItem, ProfileRespo
   override get IDProperty():string { return 'userID'; }
 
   override get DATABASE_COLUMN_LIST():string[] { return USER_TABLE_COLUMNS; }
+  override get DATABASE_COLUMN_EDIT_LIST():string[] { return USER_TABLE_COLUMNS_EDIT;}
   override get DATABASE_IDENTIFYING_PROPERTY_LIST():string[] { return USER.DATABASE_IDENTIFYING_PROPERTY_LIST; }
   override get PROPERTY_LIST():string[] { return USER.PROPERTY_LIST; }
 
@@ -158,7 +163,7 @@ export default class USER extends BASE_MODEL<USER, ProfileListItem, ProfileRespo
   }
 
   static getUniqueDatabaseProperties = (model:USER, baseModel:USER):Map<string, any> =>
-    BASE_MODEL.getUniquePropertiesUtility<USER>({fieldList: USER_TABLE_COLUMNS, getModelProperty: (column) => model.getPropertyFromDatabaseColumn(column) ? column : undefined,
+    BASE_MODEL.getUniquePropertiesUtility<USER>({fieldList: USER_TABLE_COLUMNS_EDIT, getModelProperty: (column) => model.getPropertyFromDatabaseColumn(column) ? column : undefined,
       model, baseModel, includeID: false, includeObjects: false, includeNull: true,
       complexFieldMap: new Map([
         ['passwordHash', (model:USER, baseModel:USER) => { return (model.passwordHash !== baseModel.passwordHash) ? model.passwordHash : undefined; }],

--- a/1-src/2-services/10-utilities/mock-utilities/mock-generate.mts
+++ b/1-src/2-services/10-utilities/mock-utilities/mock-generate.mts
@@ -16,8 +16,8 @@ import { generatePasswordHash } from '../../../1-api/2-auth/auth-utilities.mjs';
 import { DATABASE_CIRCLE_STATUS_ENUM, DATABASE_MODEL_SOURCE_ENVIRONMENT_ENUM, DATABASE_PARTNER_STATUS_ENUM, DATABASE_USER_ROLE_ENUM } from '../../2-database/database-types.mjs';
 import { DB_INSERT_CIRCLE, DB_INSERT_CIRCLE_ANNOUNCEMENT, DB_INSERT_CIRCLE_USER_STATUS,  DB_SELECT_CIRCLE_ANNOUNCEMENT_CURRENT, DB_SELECT_CIRCLE_DETAIL_BY_NAME, DB_SELECT_CIRCLE_LIST_BY_USER_SOURCE_ENVIRONMENT } from '../../2-database/queries/circle-queries.mjs';
 import { DB_ASSIGN_PARTNER_STATUS, DB_SELECT_AVAILABLE_PARTNER_LIST, getPartnerID, getUserID } from '../../2-database/queries/partner-queries.mjs';
-import { DB_INSERT_AND_SELECT_PRAYER_REQUEST, DB_INSERT_CIRCLE_RECIPIENT_PRAYER_REQUEST, DB_INSERT_PRAYER_REQUEST_COMMENT, DB_INSERT_USER_RECIPIENT_PRAYER_REQUEST, DB_SELECT_PRAYER_REQUEST_COMMENT_LIST, DB_SELECT_PRAYER_REQUEST_LIST_BY_USER_SOURCE_ENVIRONMENT, DB_UPDATE_INCREMENT_PRAYER_REQUEST_COMMENT_LIKE_COUNT } from '../../2-database/queries/prayer-request-queries.mjs';
-import { DB_DELETE_CONTACT_CACHE_BATCH, DB_DELETE_CONTACT_CACHE_BY_CIRCLE_BATCH, DB_INSERT_USER, DB_INSERT_USER_ROLE, DB_POPULATE_USER_PROFILE, DB_SELECT_USER, DB_SELECT_USER_LIST_BY_SOURCE_ENVIRONMENT, DB_UNIQUE_USER_EXISTS, DB_UPDATE_USER } from '../../2-database/queries/user-queries.mjs';
+import { DB_INSERT_CIRCLE_RECIPIENT_PRAYER_REQUEST, DB_INSERT_PRAYER_REQUEST, DB_INSERT_PRAYER_REQUEST_COMMENT, DB_INSERT_USER_RECIPIENT_PRAYER_REQUEST, DB_SELECT_PRAYER_REQUEST_COMMENT_LIST, DB_SELECT_PRAYER_REQUEST_LIST_BY_USER_SOURCE_ENVIRONMENT, DB_UPDATE_INCREMENT_PRAYER_REQUEST_COMMENT_LIKE_COUNT } from '../../2-database/queries/prayer-request-queries.mjs';
+import { DB_DELETE_CONTACT_CACHE_BATCH, DB_DELETE_CONTACT_CACHE_BY_CIRCLE_BATCH, DB_INSERT_USER, DB_INSERT_USER_ROLE, DB_POPULATE_USER_PROFILE, DB_SELECT_USER_LIST_BY_SOURCE_ENVIRONMENT, DB_UNIQUE_USER_EXISTS, DB_UPDATE_USER } from '../../2-database/queries/user-queries.mjs';
 
 
 
@@ -65,8 +65,9 @@ export const createMockUser = async(populateRelations = true):Promise<USER> => {
     }
 
     /* Save Mock User | userID assigned by Database */
-    if(await DB_INSERT_USER(user.getDatabaseProperties())) {
-        user = await DB_SELECT_USER(new Map([['email', user.email], ['passwordHash', user.passwordHash]]));
+    const saveResponse:{success:boolean, userID:number} = await DB_INSERT_USER(user.getDatabaseProperties());
+    if(saveResponse.success && saveResponse.userID > 0) {
+        user.userID = saveResponse.userID;
         await DB_INSERT_USER_ROLE({userID: user.userID, email: user.email, userRoleList: [DATABASE_USER_ROLE_ENUM.DEMO_USER]});
         log.event(`Mock Profile: ${user.userID} | '${user.displayName}' created.`);
 
@@ -100,9 +101,10 @@ export const createMockPrayerRequest = async(userID:number):Promise<PRAYER_REQUE
     request.isValid = true;
 
     /* Save to get prayerRequestID */
-    request = await DB_INSERT_AND_SELECT_PRAYER_REQUEST(request.getDatabaseProperties());
+    const savedResponse:{success:boolean, prayerRequestID:number} = await DB_INSERT_PRAYER_REQUEST(request.getDatabaseProperties());
+    request.prayerRequestID = savedResponse.prayerRequestID;
 
-    if(!request.isValid || request.prayerRequestID <= 0) {
+    if(!savedResponse.success || request.prayerRequestID <= 0) {
         log.warn('Error Saving Mock Prayer Request', request.toString());
         return new PRAYER_REQUEST();
     }

--- a/1-src/2-services/2-database/database-types.mts
+++ b/1-src/2-services/2-database/database-types.mts
@@ -91,8 +91,12 @@ export const TABLES_SUPPORTING_DT: Map<DATABASE_TABLE, Array<'createdDT' | 'modi
 ********************************************************************/
 export const USER_TABLE_COLUMNS_REQUIRED:string[] = [ 'displayName', 'email', 'passwordHash' ];
 
-export const USER_TABLE_COLUMNS:string[] = [ ...USER_TABLE_COLUMNS_REQUIRED,
-    'userID', 'modelSourceEnvironment', 'firstName', 'lastName', 'postalCode', 'dateOfBirth', 'gender', 'emailVerified', 'walkLevel', 'image', 'notes', 'maxPartners'
+export const USER_TABLE_COLUMNS_EDIT:string[] = [ ...USER_TABLE_COLUMNS_REQUIRED,
+    'modelSourceEnvironment', 'firstName', 'lastName', 'postalCode', 'dateOfBirth', 'gender', 'emailVerified', 'walkLevel', 'image', 'notes', 'maxPartners'
+];
+
+export const USER_TABLE_COLUMNS:string[] = [ ...USER_TABLE_COLUMNS_EDIT,
+    'userID', 'createdDT', 'modifiedDT'
 ];
 
 export type DATABASE_USER = { //Optional Fields for PATCH/UPDATE
@@ -166,8 +170,12 @@ export enum DATABASE_PARTNER_STATUS_ENUM {
 ********************************************************************/
 export const CIRCLE_TABLE_COLUMNS_REQUIRED:string[] = [ 'leaderID', 'name' ];
 
-export const CIRCLE_TABLE_COLUMNS:string[] = [ ...CIRCLE_TABLE_COLUMNS_REQUIRED,
-    'circleID', 'description', 'postalCode', 'isActive', 'inviteToken', 'image', 'notes'
+export const CIRCLE_TABLE_COLUMNS_EDIT:string[] = [ ...CIRCLE_TABLE_COLUMNS_REQUIRED,
+    'isActive', 'inviteToken', 'description', 'postalCode', 'image', 'notes'
+];
+
+export const CIRCLE_TABLE_COLUMNS:string[] = [ ...CIRCLE_TABLE_COLUMNS_EDIT,
+    'circleID', 'createdDT', 'modifiedDT'
 ];
 
 export type DATABASE_CIRCLE = {  //Optional Fields for PATCH/UPDATE
@@ -193,8 +201,12 @@ export enum DATABASE_CIRCLE_STATUS_ENUM {
 *********************************************************************/
 export const CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED:string[] = [ 'circleID', 'message', 'endDate' ];
 
+export const CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_EDIT:string[] = [ ...CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED,
+    'startDate'
+];
+
 export const CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS:string[] = [ ...CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED,
-    'announcementID', 'startDate'
+    'announcementID', 'createdDT'
 ];
 
 export type DATABASE_CIRCLE_ANNOUNCEMENT = {
@@ -211,21 +223,66 @@ export type DATABASE_CIRCLE_ANNOUNCEMENT = {
 *********************************************************************/
 export const PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED:string[] = [ 'requestorID', 'topic', 'description', 'expirationDate' ];
 
-export const PRAYER_REQUEST_TABLE_COLUMNS:string[] = [ ...PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED,
-    'prayerRequestID', 'prayerCount', 'isOnGoing', 'isResolved', 'tagListStringified'
+export const PRAYER_REQUEST_TABLE_COLUMNS_EDIT:string[] = [ ...PRAYER_REQUEST_TABLE_COLUMNS_REQUIRED,
+    'prayerCount', 'isOnGoing', 'isResolved', 'tagListStringified'
 ];
 
-export type DATABASE_PRAYER_REQUEST = {
+export const PRAYER_REQUEST_TABLE_COLUMNS:string[] = [ ...PRAYER_REQUEST_TABLE_COLUMNS_EDIT,
+    'prayerRequestID', 'createdDT', 'modifiedDT'
+];
+
+export interface DATABASE_PRAYER_REQUEST {
     prayerRequestID: number, 
     requestorID: number, 
     topic: string,
     description: string,
-    prayerCount: number,
     isOnGoing: boolean,
     isResolved: boolean,
-    tagListStringified: string,
-    expirationDate: Date
+    tagListStringified?: string,
+    expirationDate: Date,
+    prayerCount: number,
+    createdDT: Date,
+    modifiedDT: Date
 };
+
+
+//prayer_request joint table parsed in PRAYER_REQUEST.constructByDatabase
+export const PRAYER_REQUEST_EXTENDED_TABLE_COLUMNS:string[] = [ ...PRAYER_REQUEST_TABLE_COLUMNS,
+    //Expects ('requestorDisplayName', 'requestorFirstName', 'requestorImage'), //Assembled into requestorProfile
+    'createdDT', 'modifiedDT'
+];
+
+export interface DATABASE_PRAYER_REQUEST_EXTENDED extends DATABASE_PRAYER_REQUEST {
+    //requestorProfile:ProfileListItem
+    requestorFirstName?:string;
+    requestorDisplayName?:string;
+    requestorImage?:string;
+}
+
+
+/******************************************************************** 
+*      Database `prayer_request_comment` 
+*********************************************************************/
+export const PRAYER_REQUEST_COMMENT_TABLE_COLUMNS_REQUIRED = [ 'prayerRequestID', 'commenterID', 'message' ];
+
+export const PRAYER_REQUEST_COMMENT_TABLE_COLUMNS = [ ...PRAYER_REQUEST_COMMENT_TABLE_COLUMNS_REQUIRED,
+    'commentID', 'likeCount', 'createdDT'   //Read only
+];
+
+export interface DATABASE_PRAYER_REQUEST_COMMENT {
+  commentID: number;
+  prayerRequestID: number;
+  commenterID: number;
+  message: string;
+  createdDT: Date;
+}
+
+export interface DATABASE_PRAYER_REQUEST_COMMENT_EXTENDED extends DATABASE_PRAYER_REQUEST_COMMENT {
+    //commenterProfile:ProfileListItem
+    commenterFirstName?:string;
+    commenterDisplayName?:string;
+    commenterImage?:string;
+}
 
 
 /******************************************************************** 
@@ -233,8 +290,12 @@ export type DATABASE_PRAYER_REQUEST = {
 *********************************************************************/
 export const CONTENT_TABLE_COLUMNS_REQUIRED:string[] = [ 'recorderID', 'type', 'source', 'url' ];
 
-export const CONTENT_TABLE_COLUMNS:string[] = [ ...CONTENT_TABLE_COLUMNS_REQUIRED,
-    'contentID', 'customType', 'customSource', 'keywordListStringified', 'title', 'description', 'image', 'likeCount', 'gender', 'minimumAge', 'maximumAge', 'minimumWalkLevel', 'maximumWalkLevel', 'notes'
+export const CONTENT_TABLE_COLUMNS_EDIT:string[] = [ ...CONTENT_TABLE_COLUMNS_REQUIRED,
+    'likeCount', 'customType', 'customSource', 'keywordListStringified', 'title', 'description', 'image', 'gender', 'minimumAge', 'maximumAge', 'minimumWalkLevel', 'maximumWalkLevel', 'notes'
+];
+
+export const CONTENT_TABLE_COLUMNS:string[] = [ ...CONTENT_TABLE_COLUMNS_EDIT,
+    'contentID', 'createdDT', 'modifiedDT'   //Read only
 ];
 
 export enum DATABASE_GENDER_SELECTION_ENUM {
@@ -260,7 +321,9 @@ export type DATABASE_CONTENT = {
     maximumAge: number, 
     minimumWalkLevel: number, 
     maximumWalkLevel: number, 
-    notes?: string
+    notes?: string,
+    createdDT: Date,
+    modifiedDT: Date
 };
 
 

--- a/1-src/2-services/2-database/database-types.mts
+++ b/1-src/2-services/2-database/database-types.mts
@@ -10,23 +10,6 @@ export interface AWSDatabaseSecrets {
     engine: string,
     dbInstanceIdentifier: string
 }
-
-export interface DatabaseTableUsage {
-    totalRows:number,
-    created24Hours:number,
-    created7Days:number,
-    created30Days:number,
-    modified24Hours:number,
-    modified7Days:number,
-    modified30Days:number,
-}
-
-export interface DatabaseUserStats extends DatabaseTableUsage {
-    emailVerified:number,
-    walkLevelMap:Map<number, number>,
-    roleMap:Map<DATABASE_USER_ROLE_ENUM, number>,
-    unassignedUsers:number, //Without user_role, defaults to USER
-}
   
 
 export interface CommandResponseType extends SQL.ResultSetHeader {

--- a/1-src/2-services/2-database/queries/circle-queries.mts
+++ b/1-src/2-services/2-database/queries/circle-queries.mts
@@ -1,6 +1,6 @@
 import * as log from '../../10-utilities/logging/log.mjs';
 import { command, execute, validateColumns } from '../database.mjs';
-import { CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS, CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED, CIRCLE_TABLE_COLUMNS, CIRCLE_TABLE_COLUMNS_REQUIRED, CommandResponseType, DATABASE_CIRCLE, DATABASE_CIRCLE_ANNOUNCEMENT, DATABASE_CIRCLE_STATUS_ENUM, DATABASE_MODEL_SOURCE_ENVIRONMENT_ENUM, DATABASE_USER_ROLE_ENUM } from '../database-types.mjs';
+import { CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS, CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_EDIT, CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED, CIRCLE_TABLE_COLUMNS, CIRCLE_TABLE_COLUMNS_EDIT, CIRCLE_TABLE_COLUMNS_REQUIRED, CommandResponseType, DATABASE_CIRCLE, DATABASE_CIRCLE_ANNOUNCEMENT, DATABASE_CIRCLE_STATUS_ENUM, DATABASE_MODEL_SOURCE_ENVIRONMENT_ENUM, DATABASE_USER_ROLE_ENUM } from '../database-types.mjs';
 import CIRCLE from '../../1-models/circleModel.mjs';
 import { CircleListItem } from '../../../0-assets/field-sync/api-type-sync/circle-types.mjs';
 import { ProfileListItem } from '../../../0-assets/field-sync/api-type-sync/profile-types.mjs';
@@ -25,11 +25,11 @@ import { GENERAL_USER_ROLES } from '../../../0-assets/field-sync/input-config-sy
 */
 
 /* REQUIRED VALIDATION ONLY WHEN COLUMNS ARE INPUTS */
-const validateCircleColumns = (inputMap:Map<string, any>, includesRequired:boolean = false):boolean => 
-    validateColumns(inputMap, includesRequired, CIRCLE_TABLE_COLUMNS, CIRCLE_TABLE_COLUMNS_REQUIRED);
+const validateCircleColumns = (inputMap:Map<string, any>, forEditing:boolean, includesRequired:boolean = false):boolean =>
+    validateColumns(inputMap, includesRequired, forEditing ? CIRCLE_TABLE_COLUMNS_EDIT : CIRCLE_TABLE_COLUMNS, CIRCLE_TABLE_COLUMNS_REQUIRED);
 
-const validateCircleAnnouncementColumns = (inputMap:Map<string, any>):boolean => 
-    validateColumns(inputMap, true, CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS, CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED);
+const validateCircleAnnouncementColumns = (inputMap:Map<string, any>, forEditing:boolean, includesRequired:boolean):boolean =>
+    validateColumns(inputMap, includesRequired, forEditing ? CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_EDIT : CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS, CIRCLE_ANNOUNCEMENT_TABLE_COLUMNS_REQUIRED);
 
 
 /********************
@@ -113,7 +113,7 @@ export const DB_SELECT_LATEST_CIRCLES = async(limit:number = LIST_LIMIT):Promise
 
 export const DB_SELECT_CIRCLE_IDS = async(fieldMap:Map<string, any>):Promise<number[]> => {
     //Validate Columns prior to Query
-    if(!validateCircleColumns(fieldMap)) {
+    if(!validateCircleColumns(fieldMap, false, false)) {
         log.db('Query Rejected: DB_SELECT_CIRCLE_IDS; invalid column names', JSON.stringify(Array.from(fieldMap.keys())));
         return [];
     }
@@ -126,11 +126,11 @@ export const DB_SELECT_CIRCLE_IDS = async(fieldMap:Map<string, any>):Promise<num
     return [...rows.reverse().map(row => row.circleID)];
 }
 
-export const DB_INSERT_CIRCLE = async(fieldMap:Map<string, any>):Promise<boolean> => {
+export const DB_INSERT_CIRCLE = async(fieldMap:Map<string, any>):Promise<{success:boolean, circleID:number}> => {
     //Validate Columns prior to Query
-    if(!validateCircleColumns(fieldMap)) {
+    if(!validateCircleColumns(fieldMap, true, true)) {
         log.db('Query Rejected: DB_INSERT_CIRCLE; invalid column names', JSON.stringify(Array.from(fieldMap.keys())));
-        return false;
+        return {success:false, circleID:-1};
     }
 
     const preparedColumns:string = Array.from(fieldMap.keys()).map((key, field)=> `${key}`).join(', ');
@@ -138,12 +138,12 @@ export const DB_INSERT_CIRCLE = async(fieldMap:Map<string, any>):Promise<boolean
 
     const response:CommandResponseType = await command(`INSERT INTO circle ( ${preparedColumns} ) VALUES ( ${preparedValues} );`, Array.from(fieldMap.values())); 
     
-    return ((response !== undefined) && (response.affectedRows === 1));
+    return {success:((response !== undefined) && (response.affectedRows === 1)), circleID:response?.insertId || -1};
 }
 
 export const DB_UPDATE_CIRCLE = async(circleID:number, fieldMap:Map<string, any>):Promise<boolean> => {
     //Validate Columns prior to Query
-    if(!validateCircleColumns(fieldMap)) {
+    if(!validateCircleColumns(fieldMap, true, false)) {
         log.db('Query Rejected: DB_UPDATE_CIRCLE; invalid column names', JSON.stringify(Array.from(fieldMap.keys())));
         return false;
     }
@@ -169,7 +169,12 @@ export const DB_DELETE_CIRCLE = async(circleID:number):Promise<boolean> => { //N
  **********************************/
 //https://code-boxx.com/mysql-search-exact-like-fuzzy/
 export const DB_SELECT_CIRCLE_SEARCH = async(searchTerm:string, columnList:string[], limit:number = LIST_LIMIT):Promise<CircleListItem[]> => {
-    
+    //Validate Columns prior to Query
+    if(!validateCircleColumns(new Map(columnList.map(column => [column, -1])), false, false)) {
+        log.error('DB_SELECT_CIRCLE_SEARCH rejected for invalid columns', columnList);
+        return [];
+    }
+
     const rows = await execute('SELECT circle.circleID, circle.name, circle.image ' + 'FROM circle '
         + 'LEFT JOIN user on user.userID = circle.leaderID '
         + 'WHERE ( '
@@ -275,19 +280,21 @@ export const DB_SELECT_CIRCLE_ANNOUNCEMENT_ALL_CIRCLES = async(userID:number):Pr
     return [...rows.map(row => (CIRCLE_ANNOUNCEMENT.constructByDatabase(row as DATABASE_CIRCLE_ANNOUNCEMENT)))];
 }
 
-export const DB_INSERT_CIRCLE_ANNOUNCEMENT = async(fieldMap:Map<string, any>):Promise<boolean> => {
+export const DB_INSERT_CIRCLE_ANNOUNCEMENT = async(fieldMap:Map<string, any>):Promise<{success:boolean, announcementID:number}> => {
     //Validate Columns prior to Query
-    if(!validateCircleAnnouncementColumns(fieldMap)) {
+    if(!validateCircleAnnouncementColumns(fieldMap, true, true)) {
         log.db('Query Rejected: DB_INSERT_CIRCLE_ANNOUNCEMENT; invalid column names', JSON.stringify(Array.from(fieldMap.keys())));
-        return false;
+        return {success:false, announcementID:-1};
     }
 
     const preparedColumns:string = Array.from(fieldMap.keys()).map((key, field)=> `${key}`).join(', ');
     const preparedValues:string = Array.from(fieldMap.keys()).map((key, field)=> `?`).join(', ');
 
     const response:CommandResponseType = await command(`INSERT INTO circle_announcement ( ${preparedColumns} ) VALUES ( ${preparedValues} );`, Array.from(fieldMap.values())); 
+
+    log.db('ID Generated', response?.insertId, JSON.stringify(response));
     
-    return ((response !== undefined) && (response.affectedRows === 1));
+    return {success:((response !== undefined) && (response.affectedRows === 1)), announcementID:response?.insertId || -1};
 }
 
 export const DB_DELETE_CIRCLE_ANNOUNCEMENT = async({announcementID, circleID}:{announcementID?:number, circleID:number}):Promise<boolean> => {

--- a/1-src/2-services/2-database/queries/queries.mts
+++ b/1-src/2-services/2-database/queries/queries.mts
@@ -1,7 +1,9 @@
-import { CommandResponseType, DATABASE_TABLE, DATABASE_USER_ROLE_ENUM, DatabaseTableUsage, DatabaseUserStats, TABLES_SUPPORTING_DT } from '../database-types.mjs';
+import { CommandResponseType, DATABASE_TABLE, DATABASE_USER_ROLE_ENUM, TABLES_SUPPORTING_DT } from '../database-types.mjs';
+import { DatabaseTableUsage, DatabaseUserStats } from '../../../0-assets/field-sync/api-type-sync/utility-types.mjs';
 import { command, execute, query, validateColumns } from '../database.mjs';
 import * as log from '../../10-utilities/logging/log.mjs';
 import { WebsiteSubscription } from '../../../1-api/2-auth/auth-types.mjs';
+import { RoleEnum } from '../../../0-assets/field-sync/input-config-sync/profile-field-config.mjs';
 
 
 
@@ -82,14 +84,14 @@ export const DB_CALCULATE_USER_TABLE_STATS = async():Promise<DatabaseUserStats> 
         modified7Days: row?.modified7Days ?? 0,
         modified30Days: row?.modified30Days ?? 0,
         emailVerified: row?.emailVerified ?? 0,
-        walkLevelMap: new Map(
+        walkLevelMap: Object.fromEntries(
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(level => [
                 level, row ? (row[`walkLevel_${level}`] ?? 0) : 0
             ])
         ),
-        roleMap: new Map(Object.values(DATABASE_USER_ROLE_ENUM).map(role => [
+        roleMap: Object.fromEntries(Object.values(RoleEnum).map(role => [
             role, row ? (row[role] ?? 0) : 0
-        ])),
+        ])) as Record<RoleEnum, number>,
         unassignedUsers: row?.NO_ROLE ?? 0,
     };
 };

--- a/1-src/2-services/2-database/queries/user-queries.mts
+++ b/1-src/2-services/2-database/queries/user-queries.mts
@@ -140,7 +140,7 @@ export const DB_POPULATE_USER_PROFILE = async(user:USER):Promise<USER> => {
     //Query via Search to use cached list
     // user.contactList = await searchList(SearchType.CONTACT, generateJWTRequest(user.userID, user.getHighestRole()) as JwtSearchRequest) as ProfileListItem[];
     user.contactList = await DB_SELECT_PARTNER_LIST(user.userID, DATABASE_PARTNER_STATUS_ENUM.PARTNER);
-    if(user.isRole(RoleEnum.CIRCLE_LEADER)) user.profileAccessList = await DB_SELECT_MEMBERS_OF_ALL_LEADER_MANAGED_CIRCLES(user.userID, true);
+    if(user.isRole(RoleEnum.CIRCLE_MANAGER)) user.profileAccessList = await DB_SELECT_MEMBERS_OF_ALL_LEADER_MANAGED_CIRCLES(user.userID, true);
 
     return user;
 }

--- a/1-src/2-services/4-email/components/email-template-renders.mts
+++ b/1-src/2-services/4-email/components/email-template-renders.mts
@@ -1,5 +1,6 @@
 import { LogType } from "../../../0-assets/field-sync/api-type-sync/utility-types.mjs";
 import { makeDisplayText } from "../../../0-assets/field-sync/input-config-sync/inputField.mjs";
+import { RoleEnum } from "../../../0-assets/field-sync/input-config-sync/profile-field-config.mjs";
 import { fetchS3LogsByDateRange } from "../../10-utilities/logging/log-s3-utilities.mjs";
 import LOG_ENTRY from "../../10-utilities/logging/logEntryModel.mjs";
 import { DATABASE_TABLE, DATABASE_USER_ROLE_ENUM } from "../../2-database/database-types.mjs";
@@ -50,14 +51,14 @@ export const htmlUserStats = async():Promise<string> => {
         ['Total Users', stats.totalRows],
         ['Active', stats.emailVerified],
         ['Active as %', (stats.totalRows > 0) ? ((stats.emailVerified / stats.totalRows) * 100).toFixed(2) + '%' : '0%'],
-        ['Users', stats.roleMap.get(DATABASE_USER_ROLE_ENUM.USER)],
+        ['Users', stats.roleMap[RoleEnum.USER]],
         ['Users (Unassigned)', stats.unassignedUsers],
-        ['Demo Users', stats.roleMap.get(DATABASE_USER_ROLE_ENUM.DEMO_USER)],
-        ['Test Users', stats.roleMap.get(DATABASE_USER_ROLE_ENUM.TEST_USER)],
-        ['Circle Leaders', stats.roleMap.get(DATABASE_USER_ROLE_ENUM.CIRCLE_LEADER)],
-        ['Circle Managers', stats.roleMap.get(DATABASE_USER_ROLE_ENUM.CIRCLE_MANAGER)],
-        ['Inactive', stats.roleMap.get(DATABASE_USER_ROLE_ENUM.INACTIVE)],
-        ['*Reported*', stats.roleMap.get(DATABASE_USER_ROLE_ENUM.REPORTED)],
+        ['Demo Users', stats.roleMap[RoleEnum.DEMO_USER]],
+        ['Test Users', stats.roleMap[RoleEnum.TEST_USER]],
+        ['Circle Leaders', stats.roleMap[RoleEnum.CIRCLE_LEADER]],
+        ['Circle Managers', stats.roleMap[RoleEnum.CIRCLE_MANAGER]],
+        ['Inactive', stats.roleMap[RoleEnum.INACTIVE]],
+        ['*Reported*', stats.roleMap[RoleEnum.REPORTED]],
     ]));
 }
 
@@ -66,7 +67,7 @@ export const htmlUserWalkLevelDistribution = async():Promise<string> => {
     const stats = await DB_CALCULATE_USER_TABLE_STATS();
 
     const valueMap = new Map<string, string|number>();
-    stats.walkLevelMap.forEach((count, level) => {
+    Object.entries(stats.walkLevelMap).forEach(([level, count]) => {
         valueMap.set(`Walk Level ${level}`, count);
     });
 
@@ -78,7 +79,7 @@ export const htmlUserRoleDistribution = async():Promise<string> => {
     const stats = await DB_CALCULATE_USER_TABLE_STATS();
 
     const valueMap = new Map<string, string|number>();
-    stats.roleMap.forEach((count, role) => {
+    Object.entries(stats.roleMap).forEach(([role, count]) =>{
         valueMap.set(role.toString(), count); // Convert enum value to string label
     });
 

--- a/1-src/server.mts
+++ b/1-src/server.mts
@@ -21,7 +21,7 @@ import { JwtCircleClientRequest } from './1-api/4-circle/circle-types.mjs';
 import { EmailReportRequest } from './1-api/9-email/email-types.mjs';
 
 //Import Routes
-import apiRoutes, { GET_createMockCircle, GET_createMockPrayerRequest, GET_createMockUser, POST_populateDemoUser, POST_PrayerRequestExpiredScript } from './1-api/api.mjs';
+import apiRoutes, {GET_AdminStatistics, GET_createMockCircle, GET_createMockPrayerRequest, GET_createMockUser, POST_populateDemoUser, POST_PrayerRequestExpiredScript } from './1-api/api.mjs';
 import { DELETE_LogEntryByS3Key, DELETE_LogEntryS3ByDay, GET_LogDefaultList, GET_LogDownloadFile, GET_LogEntryByS3Key, GET_LogSearchList, POST_LogEmailReport, POST_LogEntry, POST_LogPartitionBucket, POST_LogResetFile } from './1-api/1-utility/log.mjs';
 import { authenticatePartnerMiddleware, authenticateCircleMembershipMiddleware, authenticateClientAccessMiddleware, authenticateCircleLeaderMiddleware, authenticateAdminMiddleware, jwtAuthenticationMiddleware, authenticateCircleManagerMiddleware, authenticatePrayerRequestRecipientMiddleware, authenticatePrayerRequestRequestorMiddleware, extractCircleMiddleware, extractClientMiddleware, authenticateContentApproverMiddleware, extractContentMiddleware, extractPartnerMiddleware, authenticatePendingPartnerMiddleware, authenticateLeaderMiddleware, authenticateDemoUserMiddleware } from './1-api/2-auth/authorization.mjs';
 import { GET_userContacts } from './1-api/7-chat/chat.mjs';
@@ -389,6 +389,7 @@ apiServer.get('/api/admin/mock-user', GET_createMockUser); //Optional query: pop
 apiServer.use(express.text());
 apiServer.delete('/api/admin/flush-search-cache/:type', (request:JwtSearchRequest, response:Response, next:NextFunction) => DELETE_flushSearchCacheAdmin(undefined, request, response, next)); //(Handles authentication)
 
+apiServer.get('/api/admin/statistics', GET_AdminStatistics);
 apiServer.get('/api/admin/log', GET_LogEntryByS3Key);
 apiServer.delete('/api/admin/log', DELETE_LogEntryByS3Key);
 apiServer.delete('/api/admin/log/day', DELETE_LogEntryS3ByDay);


### PR DESCRIPTION
**Note: Prayer Request Changes you've been testing 221 will be in the next PR

# Database Column Access Improvements

### Key Changes

1. Added explicit database column lists and defined `EDIT` column sets for each model.
2. Added `createdDT` and `modifiedDT`
    1. Added to all Models (available)
    2. Added to all model detail `Response` objects
    3. Added to Prayer Request & Comment List Items (We can add to more as needed)
3. Added `READ_ONLY` input type 
    1. (Currently only added to Admin configs to avoid breaking anything; but could be useful)
5. Updated DB `INSERT` calls to return { success, ID }, so all `POST` now return the newly created ID.
6. Added static constructor `PRAYER_REQUEST.constructByDatabaseCommentList` to map comments directly to List Items (comment is not it's own model).