### PR TITLE
270 | Prayer Request Searching

### DIFF
--- a/1-src/0-assets/field-sync/api-type-sync/circle-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/circle-types.mts
@@ -15,6 +15,7 @@ import { ProfileListItem } from './profile-types.mjs'
 export interface CircleListItem {
     circleID: number,
     name: string,
+    description: string,
     image?: string,
     status?: CircleStatusEnum
 }
@@ -43,23 +44,21 @@ export interface CircleEventListItem {
     image?: string
 }
 
-export interface CircleResponse {
-    circleID: number, 
+export interface CircleResponse extends CircleListItem {
     leaderID: number,
     leaderProfile: ProfileListItem, 
-    name: string,
-    description: string, 
     postalCode: string,
     isActive: boolean,
+    createdDT: string,
+    modifiedDT: string,
+
+    requestorID: number,
+    requestorStatus: CircleStatusEnum
+
     memberList?: ProfileListItem[],
     eventList?: CircleEventListItem[],
     announcementList?: CircleAnnouncementListItem[],
     prayerRequestList?: PrayerRequestListItem[],
-    requestorID: number,
-    requestorStatus: CircleStatusEnum
-    image?: string,
-    createdDT: string,
-    modifiedDT: string,
 };
 
 export interface CircleLeaderResponse extends CircleResponse  {

--- a/1-src/0-assets/field-sync/api-type-sync/content-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/content-types.mts
@@ -26,18 +26,9 @@ export interface ContentListItem {
 }
 
 
-export interface ContentResponseBody {
-    contentID: number,
+export interface ContentResponseBody extends ContentListItem{
     recorderID: number,
     recorderProfile: ProfileListItem, 
-    type: ContentTypeEnum,
-    source: ContentSourceEnum,
-    url: string,
-    keywordList: string,
-    title?: string,
-    description?: string,
-    image?: string,
-    likeCount: number,
     gender: GenderSelectionEnum,
     minimumAge: number,
     maximumAge: number,
@@ -45,7 +36,6 @@ export interface ContentResponseBody {
     maximumWalkLevel: number,
     notes?: string,
     createdDT: string,
-    modifiedDT: string,
 }
 
 export interface ContentMetaDataRequestBody {

--- a/1-src/0-assets/field-sync/api-type-sync/prayer-request-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/prayer-request-types.mts
@@ -15,6 +15,7 @@ import { CircleListItem } from './circle-types.mjs'
 
 export interface PrayerRequestListItem {
     prayerRequestID:number,
+    requestorID: number,
     requestorProfile:ProfileListItem, 
     topic:string,
     description:string,
@@ -35,20 +36,10 @@ export interface PrayerRequestCommentListItem {
     createdDT:string,
 }
 
-export interface PrayerRequestResponseBody {
-    prayerRequestID: number,
-    requestorID: number,
-    topic: string,
-    description: string,
+export interface PrayerRequestResponseBody extends PrayerRequestListItem{
     isOnGoing: boolean,
     isResolved: boolean,
-    tagList: PrayerRequestTagEnum[],
     expirationDate: string,
-    createdDT: string,
-    modifiedDT: string,
-
-    prayerCount: number,
-    prayerCountRecipient: number,
 
     commentList?: PrayerRequestCommentListItem[],
     userLikedList?: ProfileListItem[],

--- a/1-src/0-assets/field-sync/api-type-sync/profile-types.mts
+++ b/1-src/0-assets/field-sync/api-type-sync/profile-types.mts
@@ -60,12 +60,9 @@ export const PROFILE_PROPERTY_LIST = [ //Sync to ProfileResponse
     'newPrayerRequestList', 'ownedPrayerRequestList', 'expiringPrayerRequestList', 'recommendedContentList', 'contactList', 'profileAccessList'
 ];
 
-export interface ProfileResponse {
-    userID: number, 
+export interface ProfileResponse extends ProfileListItem {
     modelSourceEnvironment: ModelSourceEnvironmentEnum,
     userRole: RoleEnum,
-    displayName: string,
-    firstName: string,    
     lastName: string, 
     email:string,
     gender: GenderEnum,
@@ -75,7 +72,6 @@ export interface ProfileResponse {
     maxPartners: number,
     walkLevel: number,
     notes?: string,
-    image?: string,
     createdDT: string,
     modifiedDT: string,
 

--- a/1-src/0-assets/field-sync/input-config-sync/prayer-request-field-config.mts
+++ b/1-src/0-assets/field-sync/input-config-sync/prayer-request-field-config.mts
@@ -11,6 +11,14 @@ import InputField, { DATE_REGEX, InputSelectionField, InputType } from './inputF
 *****************************************/
 //Note: enums must have matching values to cast (string as Enum) or define (Enum[string]) equally
 
+export enum PrayerRequestSearchRefineEnum {
+    ALL = 'ALL',
+    ID = 'ID',
+    TITLE = 'TITLE',
+    DESCRIPTION = 'DESCRIPTION',
+    TAG = 'TAG'
+}
+
 //List doesn't sync with database; stored as list of strings stringified as `tagListStringified`
 export enum PrayerRequestTagEnum { 
     SELF = 'SELF',

--- a/1-src/0-assets/field-sync/input-config-sync/search-config.mts
+++ b/1-src/0-assets/field-sync/input-config-sync/search-config.mts
@@ -7,6 +7,7 @@ import { ProfileListItem } from '../api-type-sync/profile-types.mjs';
 import { CircleSearchRefineEnum, CircleStatusEnum } from './circle-field-config.mjs';
 import { ContentSearchRefineEnum } from './content-field-config.mjs';
 import { RoleEnum, UserSearchRefineEnum } from './profile-field-config.mjs';
+import { PrayerRequestSearchRefineEnum } from './prayer-request-field-config.mjs';
 
 
 
@@ -49,6 +50,8 @@ export enum SearchType {
     CONTACT = 'CONTACT',
     CIRCLE = 'CIRCLE',
     CONTENT_ARCHIVE = 'CONTENT_ARCHIVE',
+    PRAYER_REQUEST = 'PRAYER_REQUEST',
+    PRAYER_REQUEST_OWNED = 'PRAYER_REQUEST_OWNED'
   }
   
 
@@ -110,6 +113,14 @@ export enum SearchType {
                                                   getID:(item:ContentListItem) => item.contentID, IDProperty:'contentID', 
                                                   searchRefineList: [...Object.values(ContentSearchRefineEnum)], 
                                                 }),
+    [SearchType.PRAYER_REQUEST]: new SearchTypeInfo<PrayerRequestListItem>({ searchType:SearchType.PRAYER_REQUEST, displayTitle: 'Prayer Request Search', roleList:Object.values(RoleEnum), itemType: ListItemTypesEnum.PRAYER_REQUEST, 
+                                                  getID:(item:PrayerRequestListItem) => item.prayerRequestID, IDProperty: 'prayerRequestID', 
+                                                  searchRefineList: [...Object.values(PrayerRequestSearchRefineEnum)], 
+                                                }),
+    [SearchType.PRAYER_REQUEST_OWNED]: new SearchTypeInfo<PrayerRequestListItem>({ searchType:SearchType.PRAYER_REQUEST, displayTitle: 'Owned Prayer Request Search', roleList:Object.values(RoleEnum), itemType: ListItemTypesEnum.PRAYER_REQUEST, 
+                                                  getID:(item:PrayerRequestListItem) => item.prayerRequestID, IDProperty: 'prayerRequestID',
+                                                  searchRefineList: [...Object.values(PrayerRequestSearchRefineEnum)], 
+                                                })
   };
   
 export default SearchDetail;

--- a/1-src/1-api/api-search-utilities.mts
+++ b/1-src/1-api/api-search-utilities.mts
@@ -90,7 +90,7 @@ export const searchList = async(searchType:SearchType, request:JwtSearchRequest)
                 if(searchResultList !== undefined && DEBUG_SEARCH) log.event(`Searching: [Query Result] ${searchDetail.displayTitle} for '${searchTerm}' via '${searchRefine}' | ignoreCache: ${ignoreCache}`, searchResultList.length || 'Zero Matches');
 
                 /* NO RESULT IDENTIFIED */ 
-                else {
+                else if(searchResultList === undefined){
                     searchResultList = [];
                     DEBUG_SEARCH && log.event(`Searching: [Zero Result] ${searchDetail.displayTitle} for '${searchTerm}' via '${searchRefine}' | ignoreCache: ${ignoreCache}`);
                 }

--- a/1-src/1-api/api-types.mts
+++ b/1-src/1-api/api-types.mts
@@ -16,6 +16,10 @@ import { ContentSearchRefineEnum } from '../0-assets/field-sync/input-config-syn
 import { DB_SELECT_CONTENT, DB_SELECT_CONTENT_SEARCH, DB_SELECT_OWNED_LATEST_CONTENT_ARCHIVES } from '../2-services/2-database/queries/content-queries.mjs';
 import { filterContentList } from './11-content/content-utilities.mjs';
 import { filterContactList } from './3-profile/profile-utilities.mjs';
+import { PrayerRequestListItem } from "../0-assets/field-sync/api-type-sync/prayer-request-types.mjs";
+import PRAYER_REQUEST from "../2-services/1-models/prayerRequestModel.mjs";
+import { DB_SELECT_PRAYER_REQUEST, DB_SELECT_PRAYER_REQUEST_REQUESTOR_LIST, DB_SELECT_PRAYER_REQUEST_SEARCH, DB_SELECT_PRAYER_REQUEST_USER_LIST } from "../2-services/2-database/queries/prayer-request-queries.mjs";
+import { PrayerRequestSearchRefineEnum } from "../0-assets/field-sync/input-config-sync/prayer-request-field-config.mjs";
 
 
 /************************************
@@ -169,5 +173,23 @@ export const SearchDetailServer:Record<SearchType, SearchTypeInfoServer<any, BAS
                             fetchDefaultList: DB_SELECT_OWNED_LATEST_CONTENT_ARCHIVES,
                             executeSearch: (request:JwtSearchRequest, searchTerm:string, columnList:string[]) => DB_SELECT_CONTENT_SEARCH(searchTerm, columnList),
                             filterResultList: filterContentList,
+                        }),
+
+  [SearchType.PRAYER_REQUEST]: new SearchTypeInfoServer<PrayerRequestListItem, PRAYER_REQUEST>({ searchTypeInfo: SearchDetail[SearchType.PRAYER_REQUEST],
+                          refineDatabaseMapping: new Map([[PrayerRequestSearchRefineEnum.TITLE, ['topic']], [PrayerRequestSearchRefineEnum.DESCRIPTION, ['description']], [PrayerRequestSearchRefineEnum.TAG, ['tagListStringified']],
+                                    [PrayerRequestSearchRefineEnum.ALL, ['topic', 'description', 'tagListStringified']]
+                                ]), 
+                            searchByIDMap: new Map([[PrayerRequestSearchRefineEnum.ID, (ID:number) => DB_SELECT_PRAYER_REQUEST(ID).then((model) => [model.toListItem()])]]),
+                            fetchDefaultList: DB_SELECT_PRAYER_REQUEST_USER_LIST,
+                            executeSearch: (request:JwtSearchRequest, searchTerm:string, columnList:string[]) => DB_SELECT_PRAYER_REQUEST_SEARCH({searchTerm, columnList, recipientID:request.jwtUserID}),
+                        }),
+
+    [SearchType.PRAYER_REQUEST_OWNED]: new SearchTypeInfoServer<PrayerRequestListItem, PRAYER_REQUEST>({ searchTypeInfo: SearchDetail[SearchType.PRAYER_REQUEST_OWNED],
+                          refineDatabaseMapping: new Map([[PrayerRequestSearchRefineEnum.TITLE, ['topic']], [PrayerRequestSearchRefineEnum.DESCRIPTION, ['description']], [PrayerRequestSearchRefineEnum.TAG, ['tagListStringified']],
+                                    [PrayerRequestSearchRefineEnum.ALL, ['topic', 'description', 'tagListStringified']]
+                                ]), 
+                            searchByIDMap: new Map([[PrayerRequestSearchRefineEnum.ID, (ID:number) => DB_SELECT_PRAYER_REQUEST(ID).then((model) => [model.toListItem()])]]),
+                            fetchDefaultList: DB_SELECT_PRAYER_REQUEST_REQUESTOR_LIST,
+                            executeSearch: (request:JwtSearchRequest, searchTerm:string, columnList:string[]) => DB_SELECT_PRAYER_REQUEST_SEARCH({searchTerm, columnList, requestorID:request.jwtUserID}),
                         }),
 };

--- a/1-src/2-services/1-models/circleModel.mts
+++ b/1-src/2-services/1-models/circleModel.mts
@@ -99,7 +99,7 @@ export default class CIRCLE extends BASE_MODEL<CIRCLE, CircleListItem, CircleRes
 
     toLeaderJSON = ():CircleLeaderResponse => Object.fromEntries(this.getValidProperties(CIRCLE.LEADER_PROPERTY_LIST)) as CircleLeaderResponse;
 
-    override toListItem = ():CircleListItem => ({circleID: this.circleID, name: this.name, image: this.image});
+    override toListItem = ():CircleListItem => ({circleID: this.circleID, name: this.name, description: this.description, image: this.image});
 
 
    /****************************************

--- a/1-src/2-services/1-models/prayerRequestModel.mts
+++ b/1-src/2-services/1-models/prayerRequestModel.mts
@@ -149,6 +149,7 @@ export default class PRAYER_REQUEST extends BASE_MODEL<PRAYER_REQUEST, PrayerReq
         createdDT: this.createdDT ? this.createdDT.toISOString() : new Date().toISOString(),
         modifiedDT: this.modifiedDT ? this.modifiedDT.toISOString() : new Date().toISOString(),
 
+        requestorID: this.requestorID,
         requestorProfile: this.requestorProfile,
         prayerCountRecipient: this.prayerCountRecipient,
         prayerCount: this.prayerCount,

--- a/1-src/2-services/2-database/queries/circle-queries.mts
+++ b/1-src/2-services/2-database/queries/circle-queries.mts
@@ -91,7 +91,7 @@ export const DB_SELECT_CIRCLE_DETAIL_BY_NAME = async(leaderID:number, circleName
 //Used as default circle Search; TODO replace with location based eventually
 export const DB_SELECT_LATEST_CIRCLES = async(limit:number = LIST_LIMIT):Promise<CircleListItem[]> => {
 
-    const rows = await execute('SELECT circle.circleID, circle.name, circle.image ' + 'FROM circle '
+    const rows = await execute('SELECT circle.circleID, circle.name, circle.description, circle.image ' + 'FROM circle '
         + 'LEFT JOIN user on user.userID = circle.leaderID '
         + 'WHERE ( '
             + '        user.modelSourceEnvironment = ? '
@@ -108,7 +108,7 @@ export const DB_SELECT_LATEST_CIRCLES = async(limit:number = LIST_LIMIT):Promise
 
         [getModelSourceEnvironment(), getModelSourceEnvironment(), getModelSourceEnvironment(), getModelSourceEnvironment()]);
  
-    return [...rows.map(row => ({circleID: row.circleID || -1, name: row.name || '', image: row.image || ''}))];
+    return [...rows.map(row => ({circleID: row.circleID || -1, name: row.name || '', description:row.description || '', image: row.image || ''}))];
 }
 
 export const DB_SELECT_CIRCLE_IDS = async(fieldMap:Map<string, any>):Promise<number[]> => {
@@ -175,7 +175,7 @@ export const DB_SELECT_CIRCLE_SEARCH = async(searchTerm:string, columnList:strin
         return [];
     }
 
-    const rows = await execute('SELECT circle.circleID, circle.name, circle.image ' + 'FROM circle '
+    const rows = await execute('SELECT circle.circleID, circle.name, circle.description, circle.image ' + 'FROM circle '
         + 'LEFT JOIN user on user.userID = circle.leaderID '
         + 'WHERE ( '
         + `        user.modelSourceEnvironment = '${getModelSourceEnvironment()}' `
@@ -195,7 +195,7 @@ export const DB_SELECT_CIRCLE_SEARCH = async(searchTerm:string, columnList:strin
         + `LIMIT ${limit};`,    
     [...Array(columnList.length).fill(`${searchTerm}`)]);
  
-    return [...rows.map(row => ({circleID: row.circleID || -1, name: row.name || '', image: row.image || ''}))];
+    return [...rows.map(row => ({circleID: row.circleID || -1, name: row.name || '', description:row.description || '', image: row.image || ''}))];
 }
 
 export const DB_SELECT_CIRCLE_SEARCH_CACHE = async(searchTerm:string, searchRefine:CircleSearchRefineEnum):Promise<CircleListItem[]|undefined> => {
@@ -336,7 +336,7 @@ export const DB_SELECT_USER_CIRCLES = async(userID:number, status?:DATABASE_CIRC
 
     //Leader included in MEMBER search
     : (status === DATABASE_CIRCLE_STATUS_ENUM.MEMBER) ?
-    await execute('SELECT DISTINCT circle.circleID, circle.leaderID, circle.name, circle.image, ( SELECT circle_user.status WHERE circle_user.userID = ? ) as status ' 
+    await execute('SELECT DISTINCT circle.circleID, circle.leaderID, circle.name, circle.description, circle.image, ( SELECT circle_user.status WHERE circle_user.userID = ? ) as status ' 
         + 'FROM circle '
         + 'LEFT JOIN circle_user ON circle.circleID = circle_user.circleID '
         + 'WHERE ( circle_user.userID = ? AND circle_user.status = ? ) '
@@ -351,7 +351,7 @@ export const DB_SELECT_USER_CIRCLES = async(userID:number, status?:DATABASE_CIRC
         + 'GROUP BY circle.circleID '
         + 'ORDER BY circle_user.modifiedDT DESC;', [userID, status]);
  
-    return [...rows.map(row => ({circleID: row.circleID || -1, name: row.name || '', image: row.image || '', status: (row.leaderID === userID) ? CircleStatusEnum.LEADER : (row.status === undefined) ? undefined : CircleStatusEnum[row.status]}))];
+    return [...rows.map(row => ({circleID: row.circleID || -1, name: row.name || '', description:row.description || '', image: row.image || '', status: (row.leaderID === userID) ? CircleStatusEnum.LEADER : (row.status === undefined) ? undefined : CircleStatusEnum[row.status]}))];
 }
 
 //Select list of leader IDs where 'user' is a member of their circle | (Circle manager has access to 'user' profile)
@@ -549,5 +549,5 @@ export const DB_SELECT_CIRCLE_LIST_BY_USER_SOURCE_ENVIRONMENT = async(sourceEnvi
         + `LIMIT ${limit};`,
     [sourceEnvironment, maxMembers, maxSharedPrayerRequest]); 
 
-    return [...rows.map(row => ({circleID: row.circleID || -1, name: row.name || '', image: row.image || ''}))];
+    return [...rows.map(row => ({circleID: row.circleID || -1, name: row.name || '', description:row.description || '', image: row.image || ''}))];
 }

--- a/1-src/2-services/2-database/queries/prayer-request-queries.mts
+++ b/1-src/2-services/2-database/queries/prayer-request-queries.mts
@@ -226,7 +226,7 @@ export const DB_SELECT_PRAYER_REQUEST_USER_LIST = async(userID:number, includeOw
                 + 'AND circle_user.userID = ? '
             + ') '
         + ') '
-        + `ORDER BY prayer_request.modifiedDT ASC LIMIT ${limit};`, [userID, userID, userID, userID]);
+        + `ORDER BY prayer_request.modifiedDT DESC LIMIT ${limit};`, [userID, userID, userID, userID]);
 
     if(rows.length === LIST_LIMIT) log.warn(`DB_SELECT_PRAYER_REQUEST_USER_LIST: Reached limit of ${LIST_LIMIT} returned prayer requests for user:`, userID);
  
@@ -250,7 +250,7 @@ export const DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST = async(circleID:number, recip
         + 'INNER JOIN user ON user.userID = prayer_request.requestorID '
         + 'WHERE prayer_request_recipient.circleID = ? '
         +     'AND prayer_request.isResolved = FALSE '
-        + `ORDER BY prayer_request.modifiedDT ASC LIMIT ${limit};`,
+        + `ORDER BY prayer_request.modifiedDT DESC LIMIT ${limit};`,
         [recipientID, circleID]);
 
     if(rows.length === LIST_LIMIT) log.warn(`DB_SELECT_PRAYER_REQUEST_CIRCLE_LIST: Reached limit of ${LIST_LIMIT} returned prayer requests for circle:`, circleID);
@@ -272,7 +272,7 @@ export const DB_SELECT_PRAYER_REQUEST_REQUESTOR_LIST = async(userID:number, isRe
         + 'INNER JOIN user ON user.userID = prayer_request.requestorID '
         + 'WHERE prayer_request.requestorID = ? '
         + ((isResolved !== undefined) ? 'AND prayer_request.isResolved = ? ' : '')
-        + `ORDER BY prayer_request.modifiedDT ASC LIMIT ${limit};`, 
+        + `ORDER BY prayer_request.modifiedDT DESC LIMIT ${limit};`, 
     [userID, userID, ...((isResolved !== undefined) ? [isResolved] : [])]); 
  
     return [...rows.map(row => PRAYER_REQUEST.constructByDatabase(row as DATABASE_PRAYER_REQUEST_EXTENDED).toListItem())];
@@ -312,12 +312,12 @@ export const DB_SELECT_USER_RECIPIENT_PRAYER_REQUEST_LIST = async(prayerRequestI
 }
 
 export const DB_SELECT_CIRCLE_RECIPIENT_PRAYER_REQUEST_LIST = async(prayerRequestID:number):Promise<CircleListItem[]> => {
-    const rows = await execute('SELECT circle.circleID, circle.name, circle.image '
+    const rows = await execute('SELECT circle.circleID, circle.name, circle.description, circle.image '
     + 'FROM prayer_request_recipient '
     + 'LEFT JOIN circle ON circle.circleID = prayer_request_recipient.circleID  '
     + 'WHERE prayerRequestID = ? AND userID IS NULL;', [prayerRequestID]); 
  
-    return [...rows.map(row => ({circleID: row.circleID, name: row.name, image: row.image}))];
+    return [...rows.map(row => ({circleID: row.circleID, name: row.name, description:row.description, image: row.image}))];
 }
 
 export const DB_SELECT_EXPIRED_PRAYER_REQUESTS_PAGINATED = async (isOngoing:number, limit:number, cursorIndex:number):Promise<ExpiredPrayerRequest[]> => {


### PR DESCRIPTION
# 270 | Server Prayer Request Searching
_Available functionality, doesn't need to be implemented into the app now._

### Two ways of Searching:
- `SearchType.PRAYER_REQUEST`
- `/api/search-list/PRAYER_REQUEST?refine=ALL&search=pray`
- `SearchType.PRAYER_REQUEST_OWNED`
- `/api/search-list/PRAYER_REQUEST_OWNED?refine=ALL&search=prayer`

### Refining Search Options:
```
PrayerRequestSearchRefineEnum {
    ALL = 'ALL',
    ID = 'ID',
    TITLE = 'TITLE',
    DESCRIPTION = 'DESCRIPTION',
    TAG = 'TAG'
}
```

**_Note: No caching currently, since recipients are always unique it's custom to each user._
