### PR TITLE
Model Patch Bugfix

### DIFF
--- a/1-src/1-api/3-profile/profile.mts
+++ b/1-src/1-api/3-profile/profile.mts
@@ -200,6 +200,8 @@ export const PATCH_userProfile = async (request: ProfileEditRequest, response: R
             next(new Exception(500, `Edit Profile Failed :: Failed to update user ${request.clientID} account.`, 'Save Failed'));
 
         else {
+            let updated:boolean = (USER.getUniqueDatabaseProperties(editProfile, currentProfile).size > 0);
+
             //Handle userRoleList: Add new user roles, already verified permission above
             const saveUserRole:boolean = (editProfile.userRoleList.length > 1); //Only save 'USER' role for multi role users
             editProfile.userRoleList = await USER.syncDatabaseList<RoleEnum, DATABASE_USER_ROLE_ENUM>({
@@ -211,6 +213,7 @@ export const PATCH_userProfile = async (request: ProfileEditRequest, response: R
                 DBSelectList: DB_SELECT_USER_ROLES,
                 mapToDatabaseEnum: (role:RoleEnum):DATABASE_USER_ROLE_ENUM|undefined => DATABASE_USER_ROLE_ENUM[role],
             });
+            updated = updated || USER.areListSetsDifferent<RoleEnum>(editProfile.userRoleList, currentRoleList);
 
             if(currentProfile.isEmailVerified && Array.isArray(editProfile.emailSubscriptionList)) {
                 currentProfile.emailSubscriptionList = await DB_SELECT_USER_EMAIL_SUBSCRIPTION_LIST(currentProfile.userID);
@@ -222,10 +225,16 @@ export const PATCH_userProfile = async (request: ProfileEditRequest, response: R
                     DBDeleteBatch: DB_DELETE_USER_EMAIL_SUBSCRIPTION_BATCH,
                     DBSelectList: DB_SELECT_USER_EMAIL_SUBSCRIPTION_LIST,
                 });
+                updated = updated || USER.areListSetsDifferent<EmailSubscription>(editProfile.emailSubscriptionList, currentProfile.emailSubscriptionList);
             }
-            
-            editProfile.modifiedDT = new Date(); //Local update, database sets modifiedDT
-            response.status(202).send(editProfile.toJSON());
+
+            if(!updated)
+                next(new Exception(400, `Edit Profile Failed :: No valid changes provided for user ${request.clientID}.`, 'No Changes'));
+
+            else {                    
+                editProfile.modifiedDT = new Date(); //Local update, database sets modifiedDT
+                response.status(202).send(editProfile.toJSON());
+            }
         }
     } else //Necessary; otherwise no response waits for timeout | Ignored if next() already replied
         next((editProfile instanceof Exception) ? editProfile

--- a/1-src/1-api/3-profile/profile.mts
+++ b/1-src/1-api/3-profile/profile.mts
@@ -192,15 +192,11 @@ export const PATCH_userProfile = async (request: ProfileEditRequest, response: R
     if(currentProfile.isValid && !(editProfile instanceof Exception) && editProfile.isValid) {
         //Verify user roles and verify account type tokens
         const currentRoleList:RoleEnum[] = await DB_SELECT_USER_ROLES(request.clientID);
-        const fieldChanges:Map<string, any> = USER.getUniqueDatabaseProperties(editProfile, currentProfile);
-
-        if(fieldChanges.size === 0)
-            next(new Exception(400, `Edit Profile Failed :: No valid changes provided for user ${request.clientID}.`, 'No Changes'));
-
-        else if(await validateNewRoleTokenList({newRoleList:editProfile.userRoleList, jsonRoleTokenList: request.body.userRoleTokenList, email: editProfile.email, currentRoleList: currentRoleList, adminOverride: (request.jwtUserRole === RoleEnum.ADMIN)}) === false)
+        if(await validateNewRoleTokenList({newRoleList:editProfile.userRoleList, jsonRoleTokenList: request.body.userRoleTokenList, email: editProfile.email, currentRoleList: currentRoleList, adminOverride: (request.jwtUserRole === RoleEnum.ADMIN)}) === false)
             next(new Exception(401, `Edit Profile Failed :: failed to verify token for user roles: ${JSON.stringify(editProfile.userRoleList)} for user ${editProfile.email}.`, 'Ineligible Account Type'));
 
-        else if(await DB_UPDATE_USER(request.clientID, fieldChanges) === false) 
+        else if((USER.getUniqueDatabaseProperties(editProfile, currentProfile).size > 0 )
+                && await DB_UPDATE_USER(request.clientID, USER.getUniqueDatabaseProperties(editProfile, currentProfile)) === false) 
             next(new Exception(500, `Edit Profile Failed :: Failed to update user ${request.clientID} account.`, 'Save Failed'));
 
         else {

--- a/1-src/1-api/5-prayer-request/prayer-request.mts
+++ b/1-src/1-api/5-prayer-request/prayer-request.mts
@@ -113,42 +113,43 @@ export const PATCH_prayerRequest = async (request: PrayerRequestPatchRequest, re
     if(currentPrayerRequest.isValid && !(editPrayerRequest instanceof Exception) && editPrayerRequest.isValid) {  //undefined handles next(Exception)
         const fieldChanges:Map<string, any> = PRAYER_REQUEST.getUniqueDatabaseProperties(editPrayerRequest, currentPrayerRequest);
 
-        if(fieldChanges.size === 0)
+        //Handle changes in user recipient lists
+        const userRecipientCurrentList:number[] = currentPrayerRequest.userRecipientList.map((profile) => profile.userID);
+        const userRecipientToDeleteList:number[] = editPrayerRequest.removeUserRecipientIDList?.filter((id) => userRecipientCurrentList.includes(id)) || [];
+        const userRecipientToInsertList:number[] = editPrayerRequest.addUserRecipientIDList?.filter((id) => !userRecipientCurrentList.includes(id) && !userRecipientToDeleteList.includes(id)) || [];
+        //Handle changes in circle recipient lists
+        const circleRecipientCurrentList:number[] = currentPrayerRequest.circleRecipientList.map((circle) => circle.circleID);
+        const circleRecipientToDeleteList:number[] = editPrayerRequest.removeCircleRecipientIDList?.filter((id) => circleRecipientCurrentList.includes(id)) || [];
+        const circleRecipientToInsertList:number[] = editPrayerRequest.addCircleRecipientIDList?.filter((id) => !circleRecipientCurrentList.includes(id) && !circleRecipientToDeleteList.includes(id)) || [];
+
+        if(fieldChanges.size === 0
+            && userRecipientToDeleteList.length === 0 && userRecipientToInsertList.length === 0
+            && circleRecipientToDeleteList.length === 0 && circleRecipientToInsertList.length === 0)
             next(new Exception(400, `Edit Prayer Request Failed :: No valid changes provided for Prayer Request ${request.prayerRequestID}.`, 'No Changes'));
 
-        else if(await DB_UPDATE_PRAYER_REQUEST(request.prayerRequestID, fieldChanges) === false) 
+        else if((userRecipientToDeleteList.length > 0 || circleRecipientToDeleteList.length > 0) 
+            && await DB_DELETE_RECIPIENT_PRAYER_REQUEST_BATCH({prayerRequestID: request.prayerRequestID, userRecipientIDList: userRecipientToDeleteList, circleRecipientIDList: circleRecipientToDeleteList}) === false)
+            next(new Exception(500, 'Edit Prayer Request Failed :: Failed to delete batch remove recipients.', 'Remove Recipients Failed'));
+
+        else if((userRecipientToInsertList.length > 0 || circleRecipientToInsertList.length > 0) 
+            && await DB_INSERT_RECIPIENT_PRAYER_REQUEST_BATCH({prayerRequestID: request.prayerRequestID, userRecipientIDList: userRecipientToInsertList, circleRecipientIDList: circleRecipientToInsertList}) === false)
+            next(new Exception(500, 'Edit Prayer Request Failed :: Failed to insert batch add recipients.', 'Add Recipients Failed'));
+
+        else if(fieldChanges.size > 0 && await DB_UPDATE_PRAYER_REQUEST(request.prayerRequestID, fieldChanges) === false) 
             next(new Exception(500, `Edit Prayer Request Failed :: Failed to update prayer request ${request.prayerRequestID}.`, 'Save Failed'));
 
-        else { //Handle changes in user recipient lists
-            const userRecipientCurrentList:number[] = currentPrayerRequest.userRecipientList.map((profile) => profile.userID);
-            const userRecipientToDeleteList:number[] = editPrayerRequest.removeUserRecipientIDList?.filter((id) => userRecipientCurrentList.includes(id)) || [];
-            const userRecipientToInsertList:number[] = editPrayerRequest.addUserRecipientIDList?.filter((id) => !userRecipientCurrentList.includes(id) && !userRecipientToDeleteList.includes(id)) || [];
-            //Handle changes in circle recipient lists
-            const circleRecipientCurrentList:number[] = currentPrayerRequest.circleRecipientList.map((circle) => circle.circleID);
-            const circleRecipientToDeleteList:number[] = editPrayerRequest.removeCircleRecipientIDList?.filter((id) => circleRecipientCurrentList.includes(id)) || [];
-            const circleRecipientToInsertList:number[] = editPrayerRequest.addCircleRecipientIDList?.filter((id) => !circleRecipientCurrentList.includes(id) && !circleRecipientToDeleteList.includes(id)) || [];
-                
-            if((userRecipientToDeleteList.length > 0 || circleRecipientToDeleteList.length > 0) 
-                && await DB_DELETE_RECIPIENT_PRAYER_REQUEST_BATCH({prayerRequestID: request.prayerRequestID, userRecipientIDList: userRecipientToDeleteList, circleRecipientIDList: circleRecipientToDeleteList}) === false)
-                next(new Exception(500, 'Edit Prayer Request Failed :: Failed to delete batch remove recipients.', 'Remove Recipients Failed'));
+        else {
+            const savedPrayerRequest:PRAYER_REQUEST = await DB_SELECT_PRAYER_REQUEST_DETAIL(request.prayerRequestID, request.jwtUserID, true);
 
-            else if((userRecipientToInsertList.length > 0 || circleRecipientToInsertList.length > 0) 
-                && await DB_INSERT_RECIPIENT_PRAYER_REQUEST_BATCH({prayerRequestID: request.prayerRequestID, userRecipientIDList: userRecipientToInsertList, circleRecipientIDList: circleRecipientToInsertList}) === false)
-                next(new Exception(500, 'Edit Prayer Request Failed :: Failed to insert batch add recipients.', 'Add Recipients Failed'));
-
-            else {
-                const savedPrayerRequest:PRAYER_REQUEST = await DB_SELECT_PRAYER_REQUEST_DETAIL(request.prayerRequestID, request.jwtUserID, true);
-
-                // send notifications asynchronously
-                for (const circleID of (editPrayerRequest.addCircleRecipientIDList || [])) {
-                    const userIDs = await DB_SELECT_CIRCLE_USER_IDS(circleID, undefined, false);
-                    sendNotificationCircle(editPrayerRequest.requestorID, userIDs, circleID, CircleNotificationType.PRAYER_REQUEST_RECIPIENT, currentPrayerRequest.requestorProfile.displayName);
-                }
-                if(editPrayerRequest.addUserRecipientIDList !== undefined && editPrayerRequest.addUserRecipientIDList.length > 0)
-                    sendTemplateNotification(editPrayerRequest.requestorID, editPrayerRequest.addUserRecipientIDList, NotificationType.PRAYER_REQUEST_RECIPIENT, currentPrayerRequest.requestorProfile.displayName);
-
-                response.status(202).send(savedPrayerRequest.toJSON());
+            // send notifications asynchronously
+            for (const circleID of (editPrayerRequest.addCircleRecipientIDList || [])) {
+                const userIDs = await DB_SELECT_CIRCLE_USER_IDS(circleID, undefined, false);
+                sendNotificationCircle(editPrayerRequest.requestorID, userIDs, circleID, CircleNotificationType.PRAYER_REQUEST_RECIPIENT, currentPrayerRequest.requestorProfile.displayName);
             }
+            if(editPrayerRequest.addUserRecipientIDList !== undefined && editPrayerRequest.addUserRecipientIDList.length > 0)
+                sendTemplateNotification(editPrayerRequest.requestorID, editPrayerRequest.addUserRecipientIDList, NotificationType.PRAYER_REQUEST_RECIPIENT, currentPrayerRequest.requestorProfile.displayName);
+
+            response.status(202).send(savedPrayerRequest.toJSON());
         }
     } else //Necessary; otherwise no response waits for timeout | Ignored if next() already replied
         next((editPrayerRequest instanceof Exception) ? editPrayerRequest

--- a/1-src/2-services/1-models/userModel.mts
+++ b/1-src/2-services/1-models/userModel.mts
@@ -290,4 +290,8 @@ export default class USER extends BASE_MODEL<USER, ProfileListItem, ProfileRespo
         else
           return [...normalizedNewList];
     }
+
+    static areListSetsDifferent<T>(newList:T[], currentList:T[]):boolean {
+      return (newList.length !== currentList.length) || newList.some((item:T) => !currentList.includes(item));
+  }
 };

--- a/1-src/2-services/4-email/email-transporter.mts
+++ b/1-src/2-services/4-email/email-transporter.mts
@@ -65,11 +65,11 @@ export const sendTemplateEmail = async(subject:string, htmlBody:string, senderAd
 
         const result = await client.send(command);
         const succeeded:boolean = (result.$metadata.httpStatusCode === 200);
-        log.email(succeeded ? 'Successfully sent HTML email' : 'Failed to send HTML email', subject, 'to recipients: ', recipientAddresses, 'from original recipient map: ', recipientMap, 'from sender: ', senderAddress);
+        log.email(subject, succeeded ? 'Successfully sent HTML email' : 'Failed to send HTML email', 'to recipients: ', recipientAddresses, 'from original recipient map: ', recipientMap, 'from sender: ', senderAddress);
         return succeeded;
     } catch (error) {
-        log.error('Failed to send HTML email: ', subject, 'with error: ', error, 'to recipients: ', recipientMap, 'from sender: ', senderAddress); 
-        log.email('Error Failed to send HTML email', subject, 'to recipients: ', recipientMap, 'from sender: ', senderAddress, 'with error: ', error);
+        log.error(subject, 'Failed to send HTML email: ', 'with error: ', error, 'to recipients: ', recipientMap, 'from sender: ', senderAddress); 
+        log.email(subject, 'Error Failed to send HTML email', 'to recipients: ', recipientMap, 'from sender: ', senderAddress, 'with error: ', error);
         return false;
     }
 }
@@ -116,11 +116,11 @@ export const sendTextEmail = async(subject:string, text:string, senderAddress:Em
 
         const result = await client.send(command);
         const succeeded:boolean = (result.$metadata.httpStatusCode === 200);
-        log.email(succeeded ? 'Successfully sent TEXT email' : 'Failed to send TEXT email', subject, 'to recipients: ', recipientAddresses, 'from original recipient map: ', recipientMap, 'from sender: ', senderAddress);
+        log.email(subject, succeeded ? 'Successfully sent TEXT email' : 'Failed to send TEXT email', 'to recipients: ', recipientAddresses, 'from original recipient map: ', recipientMap, 'from sender: ', senderAddress);
         return succeeded;
     } catch (error) {
-        log.error('Failed to send TEXT email: ', subject, 'with error: ', error, 'to recipients: ', recipientMap, 'from sender: ', senderAddress, 'with text body: ', text); 
-        log.email('Error Failed to send TEXT email', subject, 'to recipients: ', recipientMap, 'from sender: ', senderAddress, 'with error: ', error);
+        log.error(subject, 'Failed to send TEXT email: ', 'with error: ', error, 'to recipients: ', recipientMap, 'from sender: ', senderAddress, 'with text body: ', text); 
+        log.email(subject, 'Error Failed to send TEXT email', 'to recipients: ', recipientMap, 'from sender: ', senderAddress, 'with error: ', error);
         return false;
     }
 };
@@ -207,11 +207,11 @@ export const sendLogTextEmail = async(subject:string, text:string, recipientMap:
 
         const result = await client.send(command);
         const succeeded:boolean = (result.$metadata.httpStatusCode === 200);
-        log.email(succeeded ? 'Successfully sent LOG ATTACHMENT email' : 'Failed to send LOG ATTACHMENT email', subject, 'to recipients: ', recipientAddresses, 'from original recipient map: ', recipientMap, 'from sender: ', EMAIL_SENDER_ADDRESS.SYSTEM);
+        log.email(subject, succeeded ? 'Successfully sent LOG ATTACHMENT email' : 'Failed to send LOG ATTACHMENT email', 'to recipients: ', recipientAddresses, 'from original recipient map: ', recipientMap, 'from sender: ', EMAIL_SENDER_ADDRESS.SYSTEM);
         return succeeded;
     } catch (error) {
-        log.error('Failed to send LOG ATTACHMENT email: ', subject, 'with error: ', error, 'to recipients: ', recipientMap, 'from sender: ', EMAIL_SENDER_ADDRESS.SYSTEM, 'with text body: ', text); 
-        log.email('Error Failed to send LOG ATTACHMENT email', subject, 'to recipients: ', recipientMap, 'from sender: ', EMAIL_SENDER_ADDRESS.SYSTEM, 'with error: ', error);
+        log.error(subject, 'Failed to send LOG ATTACHMENT email: ', 'with error: ', error, 'to recipients: ', recipientMap, 'from sender: ', EMAIL_SENDER_ADDRESS.SYSTEM, 'with text body: ', text); 
+        log.email(subject, 'Error Failed to send LOG ATTACHMENT email', 'to recipients: ', recipientMap, 'from sender: ', EMAIL_SENDER_ADDRESS.SYSTEM, 'with error: ', error);
         return false;
     }
 }


### PR DESCRIPTION
### Context
During the deploy I came across a logic inconsiticicy that prevented changing the nested fields on profile `userRoleList` and `emailSubscriptionList` without also changing another field.
In the last round of changes, I  tried to add `No Changes` as a shortcut detection response, but that was limited to basic model fields only.

### Here's what I decided for each Model:
- `PATCH_userProfile`
    - Reverted to original.  Then added `update` tracking variable and `areListSetsDifferent` utility to accurately identify "No Changes" to return 400 error response.
- `PATCH_prayerRequest`
    - Computing insert/delete of recipient lists at the top.  Then able to check for "No Changes" between basic fields and insert/delete of recipient lists.
- `PATCH_circle`
    - Leaving  simple `getUniqueDatabaseProperties` check for basic fields; as there are no nested fields within the model call.
- `PATCH_contentArchive`
    - Leaving  simple `getUniqueDatabaseProperties` check for basic fields; as there are no nested fields within the model call.


### Extra
Moved `Subject` to first parameter of `log.email`, so it reads better and subject doesn't get cut off when displaying only first line of the log message.